### PR TITLE
fix: remove unused property `content`  in `/data`

### DIFF
--- a/inc/API.php
+++ b/inc/API.php
@@ -465,9 +465,8 @@ class API extends BaseAPI {
 				 * @var int $post_id
 				 */
 				$post_data = [
-					'ID'      => $post_id,
-					'title'   => get_the_title( $post_id ),
-					'content' => apply_filters( 'the_content', get_post_field( 'post_content', $post_id ) ),
+					'ID'    => $post_id,
+					'title' => get_the_title( $post_id ),
 				];
 
 				if ( 'moderation' === $status ) {

--- a/tests/e2e/specs/dashboard.spec.js
+++ b/tests/e2e/specs/dashboard.spec.js
@@ -149,17 +149,14 @@ test.describe( 'Dashboard', () => {
 							{
 								ID: 123,
 								title: 'Checkout',
-								content: 'Test checkout content',
 							},
 							{
 								ID: 94,
 								title: 'Portofolio',
-								content: 'Test portfolio content',
 							},
 							{
 								ID: 1,
 								title: 'Hello world!',
-								content: 'Test hello world content',
 							},
 						],
 						more: false,


### PR DESCRIPTION
### Description

Remove unused property `content`  in `/data`.

New response shape:

```json
{
    "posts": [
        {
            "ID": 177,
            "title": "More devops than I bargained for"
        },
        {
            "ID": 175,
            "title": "The promise of Rust"
        },
        {
            "ID": 173,
            "title": "The virtue of unsynn"
        },
        {
            "ID": 159,
            "title": "Is the job market for software developers collapsing?"
        },
        {
            "ID": 161,
            "title": "Dividing an array into fair sized chunks"
        }
    ],
    "more": false,
    "totalChunks": "6"
}
```

### Testing

Check if the WordPress import flow works the same without any crashing.