### PR TITLE
fix: add cache protection to API requests in chat functionality

### DIFF
--- a/src/frontend/App.js
+++ b/src/frontend/App.js
@@ -185,9 +185,7 @@ class App {
 						message,
 					} )
 				),
-				headers: {
-					'Cache-Control': 'no-cache',
-				},
+				headers: this.getDefaultHeaders(),
 			} );
 
 			if ( response.error ) {
@@ -240,9 +238,7 @@ class App {
 						? { record_id: this.recordID }
 						: {} ),
 				},
-				headers: {
-					'Cache-Control': 'no-cache',
-				},
+				headers: this.getDefaultHeaders(),
 			} );
 
 			if ( response.error ) {
@@ -477,6 +473,12 @@ class App {
 		return addQueryArgs( url, {
 			t: Date.now(),
 		} );
+	}
+
+	getDefaultHeaders() {
+		return {
+			'Cache-Control': 'no-cache',
+		};
 	}
 
 	async renderUI() {


### PR DESCRIPTION
### Changes

- Add a timestamp to each request to prevent any aggressive caching method.
- Add `no-cache` to the status check response endpoint check.

### Testing

Install a Cache Plugin and include the path `/wp-json/hyve/v1/` in the caching rules to simulate a misconfiguration. The request should work even if the plugin tries to cache that endpoint.