### PR TITLE
fix: style for suggestion buttons

### DIFF
--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -403,6 +403,12 @@
 			padding: 6px 8px;
 			border-radius: 8px;
 			cursor: pointer;
+			font-size: 13px;
+			text-transform: none;
+			font-weight: 500;
+			text-align: left;
+			line-height: 1.5;
+			white-space: normal;
 		}
 	}
 }


### PR DESCRIPTION
### Changes

Set default style value for Chat Suggestion Buttons

### Screenhosts

Various looks from the popular WordPress themes (Neve included)

![CleanShot 2025-06-13 at 12 13 15@2x](https://github.com/user-attachments/assets/be32d7be-0686-4c98-b0d7-63828360b696)
![CleanShot 2025-06-13 at 12 25 56@2x](https://github.com/user-attachments/assets/0ac07f60-307b-4479-a547-459d7b3a88fd)
![CleanShot 2025-06-13 at 12 26 53@2x](https://github.com/user-attachments/assets/ebb22eae-0083-4af5-8bd5-3e0c21387a2d)
![CleanShot 2025-06-13 at 12 30 40@2x](https://github.com/user-attachments/assets/69eee86f-7563-45b6-a1d2-727d4e2e51cb)
