### PR TITLE
feat: add chat usage chart

### DIFF
--- a/inc/Main.php
+++ b/inc/Main.php
@@ -167,6 +167,7 @@ class Main {
 					'docs'           => 'https://docs.themeisle.com/article/2009-hyve-documentation',
 					'qdrant_docs'    => 'https://docs.themeisle.com/article/2066-integrate-hyve-with-qdrant',
 					'pro'            => 'https://themeisle.com/plugins/hyve/',
+					'chart'          => $this->get_chart_data(),
 				]
 			)
 		);
@@ -458,5 +459,37 @@ class Main {
 		$configs[ HYVE_PRODUCT_SLUG ] = $config;
 
 		return $configs;
+	}
+
+	/**
+	 * Get chart data.
+	 * 
+	 * @return array{legend: array{messagesLabel: string, sessionsLabel: string}, data: array{messages: array<int>, sessions: array<int>}, labels: array<string>} The chart data.
+	 */
+	public function get_chart_data() {
+		$data = Threads::get_chart_datasets();
+	
+		$labels = array_map(
+			function ( $date ) {
+				return date_i18n(
+				// translators: the date format for displaying the chart labels. The value associated with the label is the number of messages per day from users.
+					__( 'M j', 'hyve-lite' ),
+					strtotime( $date )
+				);
+			},
+			$data['labels']
+		);
+
+		return [
+			'legend' => [
+				'messagesLabel' => _x( 'User Messages per Day', 'chart legend label', 'hyve-lite' ),
+				'sessionsLabel' => _x( 'Active Sessions per Day', 'chart legend label', 'hyve-lite' ),
+			],
+			'data'   => [
+				'messages' => $data['messages'],
+				'sessions' => $data['sessions'],
+			],
+			'labels' => $labels,
+		];
 	}
 }

--- a/inc/Threads.php
+++ b/inc/Threads.php
@@ -11,6 +11,9 @@ namespace ThemeIsle\HyveLite;
  * Class Threads
  */
 class Threads {
+
+	public const CHART_DATA_TRANSIENT = 'hyve_charts_data';
+
 	/**
 	 * Constructor.
 	 */
@@ -181,7 +184,16 @@ class Threads {
 
 		update_post_meta( $post_id, '_hyve_thread_data', $thread_data );
 		update_post_meta( $post_id, '_hyve_thread_count', count( $thread_data ) );
+		
+		wp_update_post(
+			[
+				'ID'                => $post_id,
+				'post_modified'     => current_time( 'mysql' ),
+				'post_modified_gmt' => current_time( 'mysql', 1 ),
+			]
+		);
 
+		delete_transient( self::CHART_DATA_TRANSIENT );
 		return $post_id;
 	}
 
@@ -216,5 +228,117 @@ class Threads {
 		}
 
 		return $messages;
+	}
+
+	/**
+	 * Get the datasets for charts.
+	 * 
+	 * @return  array{messages: int[], labels: string[], sessions: int[]} The datasets.
+	 */
+	public static function get_chart_datasets() {
+		$cached_data = get_transient( self::CHART_DATA_TRANSIENT );
+
+		if ( false !== $cached_data ) {
+			return $cached_data;
+		}
+	
+		$days                 = 90;
+		$current_timestamp    = time();
+		$start_date_timestamp = strtotime( "-{$days} days", $current_timestamp );
+		$start_date           = gmdate( 'Y-m-d', $start_date_timestamp );
+
+		$messages_per_day = [];
+		$sessions_per_day = [];
+		$paged            = 1;
+		$posts_per_page   = 30; // Process in batches.
+
+		do {
+			$args = [
+				'post_type'      => 'hyve_threads',
+				'posts_per_page' => $posts_per_page,
+				'paged'          => $paged,
+				'post_status'    => 'publish',
+				'orderby'        => 'modified',
+				'order'          => 'DESC',
+				'date_query'     => [
+					[
+						'column' => 'post_modified_gmt',
+						'after'  => $start_date,
+					],
+				],
+				'fields'         => 'ids',
+			];
+
+			$query = new \WP_Query( $args );
+
+			if ( $query->have_posts() ) {
+				foreach ( $query->posts as $post_id ) {
+					/**
+					 * The post id.
+					 *
+					 * @var int $post_id
+					 */
+
+					$thread_data = get_post_meta( $post_id, '_hyve_thread_data', true );
+					if ( ! is_array( $thread_data ) ) {
+						continue;
+					}
+
+					// Find the earliest message in this thread within the range.
+					$thread_dates = [];
+					foreach ( $thread_data as $message_entry ) {
+						if (
+							isset( $message_entry['sender'], $message_entry['time'] ) &&
+							'user' === $message_entry['sender'] &&
+							$message_entry['time'] >= $start_date_timestamp
+						) {
+							$message_date = gmdate( 'Y-m-d', $message_entry['time'] );
+							if ( ! isset( $messages_per_day[ $message_date ] ) ) {
+								$messages_per_day[ $message_date ] = 0;
+							}
+							++$messages_per_day[ $message_date ];
+
+							$thread_dates[ $message_date ] = true;
+						}
+					}
+					// Count this thread as a session for the earliest day it appears in the range.
+					if ( ! empty( $thread_dates ) ) {
+						$first_date = array_key_first( $thread_dates );
+						if ( ! isset( $sessions_per_day[ $first_date ] ) ) {
+							$sessions_per_day[ $first_date ] = 0;
+						}
+						++$sessions_per_day[ $first_date ];
+					}
+				}
+			}
+			++$paged;
+		} while ( $query->max_num_pages >= $paged );
+
+		wp_reset_postdata();
+
+		// Ensure all days in the range are present, even if with 0 messages/sessions.
+		$labels   = [];
+		$messages = [];
+		$sessions = [];
+		for ( $i = $days - 1; $i >= 0; $i-- ) {
+			$timestamp = strtotime( "-{$i} days", $current_timestamp );
+			if ( false === $timestamp ) {
+				continue;
+			}
+			$date_key   = gmdate( 'Y-m-d', $timestamp );
+			$labels[]   = $date_key;
+			$messages[] = isset( $messages_per_day[ $date_key ] ) ? $messages_per_day[ $date_key ] : 0;
+			$sessions[] = isset( $sessions_per_day[ $date_key ] ) ? $sessions_per_day[ $date_key ] : 0;
+		}
+
+		$output_data = [
+			'labels'   => $labels,
+			'messages' => $messages,
+			'sessions' => $sessions,
+		];
+
+		set_transient( self::CHART_DATA_TRANSIENT, $output_data, HOUR_IN_SECONDS );
+
+		return $output_data;
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@wordpress/icons": "^10.13.0",
+        "chart.js": "^4.5.0",
         "classnames": "^2.5.1",
         "object-hash": "^3.0.0"
       },
@@ -3171,6 +3172,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
@@ -8721,6 +8728,18 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/check-node-version": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@wordpress/icons": "^10.13.0",
+    "chart.js": "^4.5.0",
     "classnames": "^2.5.1",
     "object-hash": "^3.0.0"
   }

--- a/src/backend/components/UsageChart.js
+++ b/src/backend/components/UsageChart.js
@@ -1,0 +1,179 @@
+/**
+ * External dependencies.
+ */
+import {
+	Chart,
+	BarController,
+	CategoryScale,
+	LinearScale,
+	BarElement,
+	Tooltip,
+	Legend,
+} from 'chart.js';
+
+/**
+ * WordPress dependencies.
+ */
+import { useState, useEffect, useRef, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+import { SelectControl } from '@wordpress/components';
+
+Chart.register(
+	BarController,
+	CategoryScale,
+	LinearScale,
+	BarElement,
+	Tooltip,
+	Legend
+);
+
+const UsageChart = ( {
+	id,
+	legendLabel,
+	data,
+	labels,
+	datasetBackgroundColor,
+	datasetBorderColor,
+} ) => {
+	const chartRef = useRef( null );
+	const [ chartInstance, setChartInstance ] = useState( null );
+
+	// Effect for creating and destroying the chart instance
+	useEffect( () => {
+		if ( ! chartRef.current ) {
+			return;
+		}
+
+		const ctx = chartRef.current.getContext( '2d' );
+		const newChart = new Chart( ctx, {
+			type: 'bar',
+			data: {
+				labels: [],
+				datasets: [
+					{
+						label: legendLabel,
+						data: [],
+						backgroundColor: datasetBackgroundColor,
+						borderColor: datasetBorderColor,
+						borderWidth: 1,
+					},
+				],
+			},
+			options: {
+				responsive: true,
+				scales: {
+					x: {
+						ticks: {
+							maxTicksLimit: 15,
+						},
+					},
+					y: {
+						beginAtZero: true,
+					},
+				},
+			},
+		} );
+		setChartInstance( newChart );
+
+		return () => {
+			if ( newChart ) {
+				newChart.destroy();
+			}
+			setChartInstance( null );
+		};
+	}, [ legendLabel, datasetBackgroundColor, datasetBorderColor ] );
+
+	// Effect for updating chart data when dateRange or chart prop changes
+	useEffect( () => {
+		if ( chartInstance && labels ) {
+			chartInstance.data.labels = labels;
+			chartInstance.data.datasets[ 0 ].data = data;
+
+			if (
+				legendLabel &&
+				chartInstance.data.datasets[ 0 ].label !== legendLabel
+			) {
+				chartInstance.data.datasets[ 0 ].label = legendLabel;
+			}
+
+			chartInstance.update();
+		} else if ( chartInstance ) {
+			chartInstance.data.labels = [];
+			chartInstance.data.datasets[ 0 ].data = [];
+			if ( legendLabel ) {
+				chartInstance.data.datasets[ 0 ].label = legendLabel;
+			}
+			chartInstance.update();
+		}
+	}, [ chartInstance, legendLabel, labels, data ] );
+
+	return (
+		<div>
+			<canvas id={ id } ref={ chartRef }></canvas>
+		</div>
+	);
+};
+
+export const UsageCharts = ( { chart } ) => {
+	const [ dateRange, setDateRange ] = useState( 30 );
+
+	const filteredLabels = useMemo( () => {
+		return chart.labels.slice( -dateRange );
+	}, [ chart.labels, dateRange ] );
+
+	const filteredMessageData = useMemo( () => {
+		return chart.data.messages.slice( -dateRange );
+	}, [ chart.data.messages, dateRange ] );
+
+	const filteredSessionsData = useMemo( () => {
+		return chart.data.sessions.slice( -dateRange );
+	}, [ chart.data.sessions, dateRange ] );
+
+	return (
+		<div className="flex flex-col gap-1">
+			<div className="flex grow justify-end">
+				<SelectControl
+					label={ __( 'Show data for', 'hyve-lite' ) }
+					options={ [
+						{
+							value: 7,
+							label: __( 'Last 7 days', 'hyve-lite' ),
+						},
+						{
+							value: 14,
+							label: __( 'Last 14 days', 'hyve-lite' ),
+						},
+						{
+							value: 30,
+							label: __( 'Last 30 days', 'hyve-lite' ),
+						},
+						{
+							value: 90,
+							label: __( 'Last 90 days', 'hyve-lite' ),
+						},
+					] }
+					value={ dateRange }
+					onChange={ ( value ) => setDateRange( value ) }
+					labelPosition="side"
+				/>
+			</div>
+			<UsageChart
+				id="messages-chart"
+				legendLabel={ chart.legend.messagesLabel }
+				labels={ filteredLabels }
+				data={ filteredMessageData }
+				datasetBorderColor={ 'rgba(54, 162, 235, 0.6)' }
+				datasetBackgroundColor={ 'rgba(54, 162, 235, 1)' }
+			/>
+			<UsageChart
+				id="sessions-chart"
+				legendLabel={ chart.legend.sessionsLabel }
+				labels={ filteredLabels }
+				data={ filteredSessionsData }
+				datasetBorderColor={ 'rgba(153, 102, 255, 0.6)' }
+				datasetBackgroundColor={ 'rgba(153, 102, 255, 1)' }
+			/>
+		</div>
+	);
+};

--- a/src/backend/parts/Home.js
+++ b/src/backend/parts/Home.js
@@ -8,6 +8,7 @@ import { Button, Panel, PanelRow } from '@wordpress/components';
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 
 import { archive, brush, help } from '@wordpress/icons';
+import { UsageCharts } from '../components/UsageChart';
 
 const { setRoute: changeRoute } = dispatch( 'hyve' );
 
@@ -152,6 +153,16 @@ const Dashboard = () => {
 					</div>
 				</PanelRow>
 			</Panel>
+			{ 0 < window.hyve?.chart?.data?.messages?.length && (
+				<>
+					<br />
+					<Panel header={ __( 'Chat Usage', 'hyve-lite' ) }>
+						<PanelRow>
+							<UsageCharts chart={ window.hyve.chart } />
+						</PanelRow>
+					</Panel>
+				</>
+			) }
 		</div>
 	);
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -7,6 +7,18 @@ interface HyveAssets {
 	images: string;
 }
 
+interface HyveChart {
+	legend: {
+		messagesLabel: string;
+		sessionsLabel: string;
+	};
+	data: {
+		messages: number[];
+		sessions: number[];
+	};
+	labels: string[];
+}
+
 interface HyveData {
 	api: string;
 	postTypes: PostType[];
@@ -18,6 +30,7 @@ interface HyveData {
 	docs: string;
 	qdrant_docs: string;
 	pro: string;
+	chart: HyveChart;
 }
 
 declare global {

--- a/tests/e2e/specs/dashboard.spec.js
+++ b/tests/e2e/specs/dashboard.spec.js
@@ -357,4 +357,64 @@ test.describe( 'Dashboard', () => {
 		).toBeHidden();
 		await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
 	} );
+
+	test( 'check chart rendering', async ( { page } ) => {
+		await page.evaluate( () => {
+			window.hyve = window.hyve || {};
+			window.hyve.chart = {
+				legend: {
+					messagesLabel: 'User messages',
+					sessionsLabel: 'Sessions',
+				},
+				data: {
+					messages: [ 0, 0, 0 ],
+					sessions: [ 1, 2, 3 ],
+				},
+				labels: [ 'Mar 20', 'Mar 21', 'Mar 22' ],
+			};
+		} );
+
+		await page
+			.getByRole( 'button', { name: 'Knowledge Base', exact: true } )
+			.click( { force: true } );
+		await page
+			.getByRole( 'button', { name: 'Dashboard' } )
+			.click( { force: true } );
+		await page.locator( '#messages-chart' ).scrollIntoViewIfNeeded();
+		await page.locator( '#sessions-chart' ).scrollIntoViewIfNeeded();
+
+		await expect( page.locator( '#messages-chart' ) ).toBeVisible();
+		await expect( page.locator( '#sessions-chart' ) ).toBeVisible();
+		await expect( page.getByText( 'Show data for' ) ).toBeVisible();
+		await expect( page.getByLabel( 'Show data for' ) ).toBeVisible();
+	} );
+
+	test( 'check chart hiding when the data is empty', async ( { page } ) => {
+		await page.evaluate( () => {
+			window.hyve = window.hyve || {};
+			window.hyve.chart = {
+				legend: {
+					messagesLabel: 'User messages',
+					sessionsLabel: 'Sessions',
+				},
+				data: {
+					messages: [],
+					sessions: [],
+				},
+				labels: [],
+			};
+		} );
+
+		await page
+			.getByRole( 'button', { name: 'Knowledge Base', exact: true } )
+			.click( { force: true } );
+		await page
+			.getByRole( 'button', { name: 'Dashboard' } )
+			.click( { force: true } );
+
+		await expect( page.locator( '#messages-chart' ) ).toBeHidden();
+		await expect( page.locator( '#sessions-chart' ) ).toBeHidden();
+		await expect( page.getByText( 'Show data for' ) ).toBeHidden();
+		await expect( page.getByLabel( 'Show data for' ) ).toBeHidden();
+	} );
 } );


### PR DESCRIPTION
### Changes

- Add a chart that showcases how many messages the users created and active sessions in the chat in the last 7,14,30,90 days.
- When a new message is added to a thread, the thread modification date is changed so that it can be included in the analysis.
- The criteria to be included in the count: the thread modification date should be newer than 90 days, and the messages in the thread are counted if their timestamp is newer than 90 days. (The dashboard gets all the 90-day values, and they are sliced (7, 14, 30) in the UI).


![CleanShot 2025-06-18 at 13 24 17@2x](https://github.com/user-attachments/assets/f74e431c-4941-45a9-a0ed-a450bebe5cd9)


