### PR TITLE
Optimize wp.org listing: title, excerpt, tags

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -35,3 +35,4 @@ tailwind.config.js
 /phpunit.xml
 /dist
 /artifact
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# Agent workflow
+
+## Project Overview
+
+Hyve Lite is an AI-powered chatbot WordPress plugin that transforms website content into interactive conversations using OpenAI APIs and optional Qdrant vector database integration. It includes a React admin dashboard, a vanilla JS frontend chat widget, and a Gutenberg block.
+
+## Build & Development Commands
+
+```bash
+# Install dependencies
+npm ci
+composer install
+
+# Build all bundles (backend, frontend, block, addons)
+npm run build
+
+# Dev mode with hot reload
+npm start
+
+# Build individual bundles
+npm run build:backend    # Admin dashboard
+npm run build:frontend   # Chat widget
+npm run build:block      # Gutenberg block
+npm run build:addons     # Post row actions
+```
+
+## Linting & Formatting
+
+```bash
+# PHP
+composer run lint         # PHPCS (WordPress-VIP-Go standard)
+composer run format       # PHPCBF auto-fix
+composer run phpstan      # Static analysis (2GB memory limit)
+
+# JavaScript
+npm run lint:js           # ESLint (WordPress preset)
+npm run format            # wp-scripts format ./src
+npm run lint:css          # Stylelint
+```
+
+## Testing
+
+```bash
+# E2E tests (requires wp-env)
+npm run wp-env start
+npm run test:playwright
+npm run test:playwright:debug   # Debug mode
+npm run test:playwright:ui      # Interactive UI mode
+
+# PHP unit tests in wp-env
+npm run env:test:unit
+
+# Standalone PHPUnit
+composer run phpunit
+```
+
+## Architecture
+
+### PHP (Backend)
+
+All PHP classes live in `inc/` under the `ThemeIsle\HyveLite` namespace (PSR-4 autoloaded).
+
+- **Main.php** — Main plugin entry point, registered on `plugins_loaded`. Instantiates all other classes, registers admin menu, manages plugin settings (`hyve_settings` option).
+- **API.php** / **BaseAPI.php** — REST API endpoints for chat, settings, and knowledge base operations. BaseAPI is the abstract base class.
+- **OpenAI.php** — Client for OpenAI embeddings, chat completions, and content moderation.
+- **Qdrant_API.php** — Optional vector database integration for similarity search (alternative to local DB).
+- **DB_Table.php** — Custom `{prefix}_hyve` table for storing vector embeddings locally.
+- **Threads.php** — Custom post type (`hyve_threads`) for persisting chat sessions.
+- **Block.php** — Registers the `hyve/chat` Gutenberg block and `[hyve]` shortcode.
+- **Tokenizer.php** / **Cosine_Similarity.php** — Token counting and vector similarity utilities.
+
+Plugin constants are defined in `hyve-lite.php`: `HYVE_LITE_BASEFILE`, `HYVE_LITE_URL`, `HYVE_LITE_PATH`, `HYVE_LITE_VERSION`, `HYVE_PRODUCT_SLUG`.
+
+### JavaScript (Frontend)
+
+Four separate webpack entry points built with `@wordpress/scripts`:
+
+1. **src/backend/** — Admin dashboard React app using `@wordpress/element` and `@wordpress/data` for state management. Components in `components/`, page sections in `parts/`.
+2. **src/frontend/** — Client-facing chat widget. Vanilla JS class (`App`) — no React. Manages chat state, threads, audio, and localStorage persistence.
+3. **src/block/** — Gutenberg block with two variations: inline and floating. Server-rendered via `render.php`.
+4. **src/addons/** — Post list table row actions for quick knowledge base add/remove.
+
+### Data Flow
+
+Posts are indexed into the knowledge base by generating OpenAI embeddings and storing them either in the custom `wp_hyve` DB table (with cosine similarity search) or in Qdrant (vector DB). Chat requests go through the REST API, which retrieves relevant context via similarity search and sends it to OpenAI for response generation.
+
+## Coding Standards
+
+- **PHP**: WordPress-VIP-Go + WordPress-Core standards. Text domain: `hyve-lite`. PHPStan level 8 compliance. Always add `// translators:` comments for `sprintf` contexts.
+- **JavaScript**: WordPress ESLint preset. Use `@wordpress/element` (not React directly) for components. Use `@wordpress/data` for shared state. Use `@wordpress/i18n` with text domain `hyve-lite`.
+- **Indentation**: Tabs (size 4). YAML uses spaces (size 2).
+
+## Version Management
+
+Versions are synced across `package.json`, `composer.json`, `hyve-lite.php`, and `readme.txt` via Grunt (`grunt version`). Semantic Release handles automated versioning using Conventional Commits.

--- a/composer.lock
+++ b/composer.lock
@@ -8,21 +8,21 @@
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.3.50",
+            "version": "3.3.51",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "3c1f8dfc2390e667bbc086c5d660900a7985efa6"
+                "reference": "bb2a8414b0418b18c68c9ff1df3d7fb10467928d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/3c1f8dfc2390e667bbc086c5d660900a7985efa6",
-                "reference": "3c1f8dfc2390e667bbc086c5d660900a7985efa6",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/bb2a8414b0418b18c68c9ff1df3d7fb10467928d",
+                "reference": "bb2a8414b0418b18c68c9ff1df3d7fb10467928d",
                 "shasum": ""
             },
             "require-dev": {
                 "codeinwp/phpcs-ruleset": "dev-main",
-                "yoast/phpunit-polyfills": "^2.0"
+                "yoast/phpunit-polyfills": "^4.0"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
@@ -43,9 +43,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.50"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.51"
             },
-            "time": "2025-11-25T19:36:35+00:00"
+            "time": "2026-03-30T07:58:49+00:00"
         },
         {
             "name": "guttedgarden/tiktoken",
@@ -3480,5 +3480,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e446c5d147699bcb595b4c696ba4f3a",
+    "content-hash": "24efb89a5c7a992478f35e37acb6fd80",
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.3.49",
+            "version": "3.3.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "605f78bbbd8526f7597a89077791043d9ecc8c20"
+                "reference": "3c1f8dfc2390e667bbc086c5d660900a7985efa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/605f78bbbd8526f7597a89077791043d9ecc8c20",
-                "reference": "605f78bbbd8526f7597a89077791043d9ecc8c20",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/3c1f8dfc2390e667bbc086c5d660900a7985efa6",
+                "reference": "3c1f8dfc2390e667bbc086c5d660900a7985efa6",
                 "shasum": ""
             },
             "require-dev": {
@@ -43,9 +43,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.49"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.50"
             },
-            "time": "2025-09-18T13:41:05+00:00"
+            "time": "2025-11-25T19:36:35+00:00"
         },
         {
             "name": "guttedgarden/tiktoken",

--- a/hyve-lite.php
+++ b/hyve-lite.php
@@ -43,7 +43,7 @@ define( 'HYVE_LITE_BASEFILE', __FILE__ );
 define( 'HYVE_LITE_URL', plugins_url( '/', __FILE__ ) );
 define( 'HYVE_LITE_PATH', __DIR__ );
 define( 'HYVE_LITE_VERSION', '1.3.2' );
-define( 'HYVE_PRODUCT_SLUG', basename( dirname( 'HYVE_LITE_BASEFILE' ) ) );
+define( 'HYVE_PRODUCT_SLUG', basename( HYVE_LITE_PATH ) );
 
 $vendor_file = HYVE_LITE_PATH . '/vendor/autoload.php';
 

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -96,6 +96,7 @@ class Main {
 			);
 		}
 
+		add_filter( 'themeisle_sdk_blackfriday_data', [ $this, 'add_black_friday_data' ] );
 		add_action( 'admin_init', [ $this, 'admin_init' ] );
 	}
 
@@ -103,7 +104,7 @@ class Main {
 	 * Register menu page.
 	 *
 	 * @since 1.2.0
-	 * 
+	 *
 	 * @return void
 	 */
 	public function register_menu_page() {
@@ -124,7 +125,7 @@ class Main {
 	 * Menu page.
 	 *
 	 * @since 1.2.0
-	 * 
+	 *
 	 * @return void
 	 */
 	public function menu_page() {
@@ -135,7 +136,7 @@ class Main {
 
 	/**
 	 * Init hooks on admin stage.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function admin_init() {
@@ -143,7 +144,7 @@ class Main {
 
 		$post_types        = get_post_types( [ 'public' => true ], 'objects' );
 		$post_types_for_js = [];
-	
+
 		foreach ( $post_types as $post_type ) {
 			$post_types_for_js[] = [
 				'label' => $post_type->labels->name,
@@ -183,7 +184,7 @@ class Main {
 	 * Load assets for option page.
 	 *
 	 * @since 1.2.0
-	 * 
+	 *
 	 * @return void
 	 */
 	public function enqueue_options_assets() {
@@ -214,15 +215,14 @@ class Main {
 			apply_filters( 'hyve_options_data', [] )
 		);
 
-		add_filter( 'themeisle_sdk_blackfriday_data', [ $this, 'add_black_friday_data' ] );
 		do_action( 'themeisle_internal_page', HYVE_PRODUCT_SLUG, 'dashboard' );
 	}
 
 	/**
 	 * Get Default Settings.
-	 * 
+	 *
 	 * @since 1.1.0
-	 * 
+	 *
 	 * @return array<string, mixed>
 	 */
 	public static function get_default_settings() {
@@ -259,9 +259,9 @@ class Main {
 
 	/**
 	 * Get Settings.
-	 * 
+	 *
 	 * @since 1.1.0
-	 * 
+	 *
 	 * @return array<string, mixed>
 	 */
 	public static function get_settings() {
@@ -274,11 +274,11 @@ class Main {
 
 	/**
 	 * Add the translatable label to the default value.
-	 * 
+	 *
 	 * Use this in a context where translations are correctly loaded.
-	 * 
+	 *
 	 * @since 1.2
-	 * 
+	 *
 	 * @return void
 	 */
 	public static function add_labels_to_default_settings() {
@@ -301,7 +301,7 @@ class Main {
 	 * Enqueue assets.
 	 *
 	 * @since 1.2.0
-	 * 
+	 *
 	 * @return void
 	 */
 	public function enqueue_assets() {
@@ -332,7 +332,7 @@ class Main {
 		self::add_labels_to_default_settings();
 		$settings = self::get_settings();
 		$stats    = $this->get_stats();
-		
+
 		/**
 		 * Filters whether the chat should be displayed.
 		 *
@@ -395,11 +395,11 @@ class Main {
 
 	/**
 	 * Load assets for option page.
-	 * 
+	 *
 	 * @param string $hook The name of the page hook.
 	 *
 	 * @since 1.4.0
-	 * 
+	 *
 	 * @return void
 	 */
 	public function enqueue_addons_assets( $hook ) {
@@ -448,9 +448,9 @@ class Main {
 
 	/**
 	 * Register the Knowledge Base row action shortcuts for the given post type.
-	 * 
+	 *
 	 * @param string|mixed $post_type The post type.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function register_row_action_filter_shortcut( $post_type ) {
@@ -464,10 +464,10 @@ class Main {
 
 	/**
 	 * Add shortcut via post row actions for adding/removing posts from the Knowledge Base
-	 * 
+	 *
 	 * @param array<string, mixed> $actions The row actions.
 	 * @param \WP_Post             $post The post object.
-	 * 
+	 *
 	 * @return array<string, mixed>
 	 */
 	public function add_to_knowledge_base_row_action( $actions, $post ) {
@@ -475,7 +475,7 @@ class Main {
 			$actions['hyve_knowledge_base_processing'] = __( 'Hyve is processing the post', 'hyve-lite' );
 			return $actions;
 		}
-		
+
 		$label  = __( 'Add to Hyve', 'hyve-lite' );
 		$action = 'add';
 		$class  = '';
@@ -485,7 +485,7 @@ class Main {
 			$action = 'delete';
 			$class  = 'button-link-delete';
 		}
-		
+
 		$actions['add_to_hyve_knowledge_base'] = '<button type="button" data-action="' . $action . '" data-post-id="' . $post->ID . '" class="hyve-row-action-btn button-link ' . $class . '" aria-expanded="false">' . $label . '</button>';
 
 		return $actions;
@@ -495,7 +495,7 @@ class Main {
 	 * Get stats.
 	 *
 	 * @since 1.3.0
-	 * 
+	 *
 	 * @return array<string, mixed>
 	 */
 	public function get_stats() {
@@ -508,7 +508,7 @@ class Main {
 
 	/**
 	 * Check if the Chat is enabled globally on all the pages.
-	 * 
+	 *
 	 * @return boolean True if the chat is enabled.
 	 */
 	public function is_global_chat_enabled() {
@@ -522,13 +522,13 @@ class Main {
 
 	/**
 	 * Update meta.
-	 * 
+	 *
 	 * @param int      $post_id Post ID.
 	 * @param \WP_Post $post Post object.
 	 * @param bool     $update Whether this is an existing post being updated.
 	 *
 	 * @since 1.2.0
-	 * 
+	 *
 	 * @return void
 	 */
 	public function update_meta( $post_id, $post, $update ) {
@@ -555,11 +555,11 @@ class Main {
 
 	/**
 	 * Delete post.
-	 * 
+	 *
 	 * @param int $post_id Post ID.
 	 *
 	 * @since 1.2.0
-	 * 
+	 *
 	 * @return void
 	 */
 	public function delete_post( $post_id ) {
@@ -588,15 +588,13 @@ class Main {
 
 		$config = $configs['default'];
 
-		// translators: %1$s - HTML tag, %2$s - discount, %3$s - HTML tag, %4$s - product name.
-		$message_template = __( 'Our biggest sale of the year: %1$sup to %2$s OFF%3$s on %4$s. Don\'t miss this limited-time offer.', 'hyve-lite' );
-		$product_label    = 'Hyve';
-		$discount         = '70%';
-
-		$product_label = sprintf( '<strong>%s</strong>', $product_label );
-		
-		$config['message']  = sprintf( $message_template, '<strong>', $discount, '</strong>', $product_label );
-		$config['sale_url'] = add_query_arg(
+		// translators: %s - discount.
+		$config['title']     = sprintf( __( 'Hyve Pro: %s off this week', 'hyve-lite' ), '60%' );
+		$config['cta_label'] = __( 'Get Hyve Pro', 'hyve-lite' );
+		$config['message']   = __( 'Chat history, missed question tracking, appearance customization. Make your chatbot actually useful. Exclusively for existing Hyve users.', 'hyve-lite' );
+		// translators: %s is the discount percentage.
+		$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'hyve-lite' ), '60%' );
+		$config['sale_url']            = add_query_arg(
 			[
 				'utm_term' => 'free',
 			],
@@ -610,12 +608,12 @@ class Main {
 
 	/**
 	 * Get chart data.
-	 * 
+	 *
 	 * @return array{legend: array{messagesLabel: string, sessionsLabel: string}, data: array{messages: array<int>, sessions: array<int>}, labels: array<string>} The chart data.
 	 */
 	public function get_chart_data() {
 		$data = Threads::get_chart_datasets();
-	
+
 		$labels = array_map(
 			function ( $date ) {
 				return date_i18n(
@@ -642,9 +640,9 @@ class Main {
 
 	/**
 	 * Append services errors if they exists.
-	 * 
+	 *
 	 * @param mixed|array<string, mixed> $options The dashboard options.
-	 * 
+	 *
 	 * @return mixed|array<string, mixed>
 	 */
 	public function append_services_error( $options ) {
@@ -674,7 +672,7 @@ class Main {
 
 	/**
 	 * Get the data for Formbricks survey.
-	 * 
+	 *
 	 * @return array<string, mixed> The survey data.
 	 */
 	public function get_survey_data() {
@@ -686,7 +684,7 @@ class Main {
 
 		$license_status     = apply_filters( 'product_hyve_license_status', 'invalid' );
 		$days_since_install = round( ( time() - min( $install_time_free, $install_time_pro ) ) / DAY_IN_SECONDS );
-		
+
 		$survey_data = [
 			'environmentId' => 'cmbtdc5s8s7pkuk014jwixs7n',
 			'attributes'    => [
@@ -713,7 +711,7 @@ class Main {
 
 	/**
 	 * Get the similarity threshold score for Cosine Similarity.
-	 * 
+	 *
 	 * @return float The threshold.
 	 */
 	public function get_similarity_threshold_score() {
@@ -725,12 +723,12 @@ class Main {
 
 		return 0.4;
 	}
-	
+
 	/**
 	 * Get the plugin usage.
-	 * 
+	 *
 	 * @param mixed $data The data.
-	 * 
+	 *
 	 * @return mixed The plugin data.
 	 */
 	public function plugin_usage( $data ) {
@@ -739,7 +737,7 @@ class Main {
 
 		$settings['api_key']        = ! empty( $settings['api_key'] ) ? 'yes' : 'no';
 		$settings['qdrant_api_key'] = ! empty( $settings['qdrant_api_key'] ) ? 'yes' : 'no';
-		
+
 		if ( isset( $settings['qdrant_endpoint'] ) ) {
 			unset( $settings['qdrant_endpoint'] );
 		}
@@ -752,7 +750,7 @@ class Main {
 
 		$data['settings'] = $settings;
 		$data['stats']    = $this->get_stats();
-		
+
 		return $data;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
-=== Hyve Lite — Conversational AI Chatbot ===
+=== Hyve Lite – AI Chatbot, ChatGPT-Powered Conversational Support ===
 Contributors: themeisle, hardeepasrani
-Tags: automation, support, chat, ai, openai
+Tags: ai chatbot, conversational ai, chatgpt, customer support, openai
 Requires at least: 6.2
 Tested up to: 6.9
 Requires PHP: 7.4
@@ -8,7 +8,7 @@ Stable tag: 1.3.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
-Hyve is an AI-powered chatbot that transforms your WordPress content into engaging conversations.
+Hyve is an AI-powered WordPress chatbot that transforms your content into engaging conversations. Powered by ChatGPT, with custom knowledge base.
 
 == Description ==
 


### PR DESCRIPTION
**Title:** 37c -> 62c. Adds `ChatGPT`, `Conversational`, `Support` as distinct anchors. Repeats `chat` stem ×2 for TF saturation.

**Excerpt:** 97c -> 145c. Adds `ChatGPT` and `custom knowledge base` anchors that the previous excerpt was missing entirely.

**Tags:** replaced generic `automation` + `support` + `chat` with concrete tags matching the AI chatbot category leaders (AI Engine #1, Jotform, MxChat, Chatway). New: `ai chatbot, conversational ai, chatgpt, customer support, openai`. All stem-distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)