### PR TITLE
fix: decode HTML entities in page titles

### DIFF
--- a/inc/API.php
+++ b/inc/API.php
@@ -520,7 +520,7 @@ class API extends BaseAPI {
 				 */
 				$post_data = [
 					'ID'    => $post_id,
-					'title' => get_the_title( $post_id ),
+					'title' => html_entity_decode( get_the_title( $post_id ), ENT_QUOTES, 'UTF-8' ),
 				];
 
 				if ( 'moderation' === $status ) {
@@ -672,7 +672,7 @@ class API extends BaseAPI {
 
 				$post_data = [
 					'ID'        => $post_id,
-					'title'     => get_the_title( $post_id ),
+					'title'     => html_entity_decode( get_the_title( $post_id ), ENT_QUOTES, 'UTF-8' ),
 					'date'      => get_the_date( 'c', $post_id ),
 					'thread'    => get_post_meta( $post_id, '_hyve_thread_data', true ),
 					'thread_id' => get_post_meta( $post_id, '_hyve_thread_id', true ),

--- a/inc/DB_Table.php
+++ b/inc/DB_Table.php
@@ -467,7 +467,7 @@ class DB_Table {
 	public function add_post( $post_id, $action = 'add' ) {
 		$data = [
 			'ID'      => $post_id,
-			'title'   => get_the_title( $post_id ),
+			'title'   => html_entity_decode( get_the_title( $post_id ), ENT_QUOTES, 'UTF-8' ),
 			'content' => apply_filters( 'the_content', get_post_field( 'post_content', $post_id ) ),
 		];
 


### PR DESCRIPTION
Titles from get_the_title() pass through the the_title filter (wptexturize/convert_chars), which emits HTML entities such as &#8211; for dashes. These were rendered raw in the add data field and also stored in the embedding text. Decode them with html_entity_decode() so the UI and embeddings get clean text.

Pro PR: https://github.com/Codeinwp/hyve/pull/178

## Testing

1. Create or edit a page/post with a dash in the title, e.g. `Summer Sale - Up to 50% Off`, and publish.
2. Go to **Hyve → Add Data** and find that page in the list.
3. **Before fix:** the title shows the raw entity, e.g. `Summer Sale &#8211; Up to 50% Off`.
   **After fix:** it shows the real character, `Summer Sale – Up to 50% Off`.
4. Add the page to the knowledge base and confirm the title displays correctly in the data list too.

### Extra cases (optional)
- `Pricing -- Plans & Add-ons` → checks en-dash + ampersand
- `The "Best" Coffee --- A Review` → checks smart quotes + em-dash


Closes: https://github.com/Codeinwp/hyve/issues/174