### PR TITLE
fix: refresh selectable OpenAI models, drop incompatible GPT-3.5

### DIFF
--- a/inc/OpenAI.php
+++ b/inc/OpenAI.php
@@ -76,7 +76,27 @@ class OpenAI {
 	public function __construct( $api_key = '' ) {
 		$settings         = Main::get_settings();
 		$this->api_key    = ! empty( $api_key ) ? $api_key : ( isset( $settings['api_key'] ) ? $settings['api_key'] : '' );
-		$this->chat_model = isset( $settings['chat_model'] ) ? $settings['chat_model'] : $this->chat_model;
+		$this->chat_model = self::resolve_chat_model( isset( $settings['chat_model'] ) ? $settings['chat_model'] : $this->chat_model );
+	}
+
+	/**
+	 * Resolve the effective chat model.
+	 *
+	 * GPT-3.5 models don't support the structured-output (`json_schema`) response
+	 * format Hyve requires, so they always error. Any stored GPT-3.5 model (no
+	 * longer offered in the UI) falls back to the default so existing sites keep
+	 * working without manual intervention.
+	 *
+	 * @param mixed $model The stored chat model.
+	 *
+	 * @return string The model to use for requests.
+	 */
+	public static function resolve_chat_model( $model ) {
+		if ( ! is_string( $model ) || '' === $model || 0 === strpos( $model, 'gpt-3.5' ) ) {
+			return 'gpt-4o-mini';
+		}
+
+		return $model;
 	}
 
 	/**

--- a/src/backend/parts/settings/Assistant.js
+++ b/src/backend/parts/settings/Assistant.js
@@ -10,12 +10,87 @@ import {
 	Panel,
 	PanelRow,
 	RangeControl,
-	RadioControl,
+	SelectControl,
 } from '@wordpress/components';
 
 import { useState } from '@wordpress/element';
 
 import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Selectable chat models.
+ *
+ * Only models verified to support every feature Hyve relies on — structured
+ * outputs (`json_schema`) plus the `temperature`/`top_p` controls — are listed.
+ * Reasoning-only models (GPT-5, GPT-5.5, the `o`-series) reject those params,
+ * and GPT-3.5 lacks structured outputs, so they are intentionally excluded.
+ */
+const MODEL_OPTIONS = [
+	{
+		label: __( 'GPT-5.4', 'hyve-lite' ),
+		value: 'gpt-5.4',
+		description: __(
+			'Newest and most capable — best for complex questions.',
+			'hyve-lite'
+		),
+	},
+	{
+		label: __( 'GPT-5.4 mini', 'hyve-lite' ),
+		value: 'gpt-5.4-mini',
+		description: __(
+			'Newer model with a strong balance of quality and cost.',
+			'hyve-lite'
+		),
+	},
+	{
+		label: __( 'GPT-5.4 nano', 'hyve-lite' ),
+		value: 'gpt-5.4-nano',
+		description: __(
+			'Newer fast, low-cost option for high-traffic chats.',
+			'hyve-lite'
+		),
+	},
+	{
+		label: __( 'GPT-4.1', 'hyve-lite' ),
+		value: 'gpt-4.1',
+		description: __(
+			'Capable and proven — great for detailed answers.',
+			'hyve-lite'
+		),
+	},
+	{
+		label: __( 'GPT-4.1 mini', 'hyve-lite' ),
+		value: 'gpt-4.1-mini',
+		description: __(
+			'Faster and cheaper than GPT-4.1 — solid all-rounder.',
+			'hyve-lite'
+		),
+	},
+	{
+		label: __( 'GPT-4.1 nano', 'hyve-lite' ),
+		value: 'gpt-4.1-nano',
+		description: __(
+			'Ultra-fast and very low cost — best for lightweight chats.',
+			'hyve-lite'
+		),
+	},
+	{
+		label: __( 'GPT-4o', 'hyve-lite' ),
+		value: 'gpt-4o',
+		description: __(
+			'Smart, cost-effective general-purpose model.',
+			'hyve-lite'
+		),
+	},
+	{
+		label: __( 'GPT-4o mini', 'hyve-lite' ),
+		value: 'gpt-4o-mini',
+		description: __(
+			'Fastest and most affordable — best for most chats.',
+			'hyve-lite'
+		),
+	},
+];
 
 const Assistant = () => {
 	const settings = useSelect( ( select ) => select( 'hyve' ).getSettings() );
@@ -55,67 +130,54 @@ const Assistant = () => {
 		setIsSaving( false );
 	};
 
+	// GPT-3.5 is no longer offered (it errors with structured outputs); show the
+	// default instead. A still-valid but no-longer-listed saved model (e.g. an
+	// older GPT-4 a site picked earlier) is appended so it isn't silently lost.
+	const savedModel = settings.chat_model;
+	const isLegacyModel =
+		'string' === typeof savedModel && savedModel.startsWith( 'gpt-3.5' );
+	const selectedModel = isLegacyModel ? 'gpt-4o-mini' : savedModel;
+
+	const modelOptions =
+		selectedModel &&
+		! MODEL_OPTIONS.some( ( option ) => option.value === selectedModel )
+			? [
+					...MODEL_OPTIONS,
+					{
+						label: selectedModel,
+						value: selectedModel,
+						description: __(
+							'Your currently selected model.',
+							'hyve-lite'
+						),
+					},
+			  ]
+			: MODEL_OPTIONS;
+
+	const selectedModelOption = modelOptions.find(
+		( option ) => option.value === selectedModel
+	);
+
 	return (
 		<div className="col-span-6 xl:col-span-4">
 			<Panel header={ __( 'Assistant Settings', 'hyve-lite' ) }>
 				<PanelRow>
-					<RadioControl
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
 						label={ __( 'Model', 'hyve-lite' ) }
-						help={ __(
-							'Choose the AI model that powers your chatbot. More advanced models provide better responses but may cost more.',
-							'hyve-lite'
-						) }
-						options={ [
-							{
-								label: __( 'GPT-4.1', 'hyve-lite' ),
-								value: 'gpt-4.1',
-								description: __(
-									'Most accurate and capable model — ideal for complex tasks.',
-									'hyve-lite'
-								),
-							},
-							{
-								label: __( 'GPT-4.1 mini', 'hyve-lite' ),
-								value: 'gpt-4.1-mini',
-								description: __(
-									'Faster and cheaper than full GPT-4.1 — great balance of cost and quality.',
-									'hyve-lite'
-								),
-							},
-							{
-								label: __( 'GPT-4.1 nano', 'hyve-lite' ),
-								value: 'gpt-4.1-nano',
-								description: __(
-									'Ultra-fast and low-cost — best for lightweight and high-traffic chats.',
-									'hyve-lite'
-								),
-							},
-							{
-								label: __( 'GPT-4o', 'hyve-lite' ),
-								value: 'gpt-4o',
-								description: __(
-									'Fast, smart, and cost-effective — best for most use cases.',
-									'hyve-lite'
-								),
-							},
-							{
-								label: __( 'GPT-4o mini', 'hyve-lite' ),
-								value: 'gpt-4o-mini',
-								description: __(
-									'Optimized for real-time chats — faster and cheaper than GPT-4o.',
-									'hyve-lite'
-								),
-							},
-							{
-								label: __( 'GPT-3.5 Turbo 0125', 'hyve-lite' ),
-								value: 'gpt-3.5-turbo-0125',
-								description: __(
-									'Legacy model for basic tasks.',
-									'hyve-lite'
-								),
-							},
-						] }
-						selected={ settings.chat_model }
+						help={
+							selectedModelOption?.description ||
+							__(
+								'Choose the AI model that powers your chatbot. More advanced models provide better responses but may cost more.',
+								'hyve-lite'
+							)
+						}
+						options={ modelOptions.map( ( { label, value } ) => ( {
+							label,
+							value,
+						} ) ) }
+						value={ selectedModel }
 						disabled={ isSaving }
 						onChange={ ( newValue ) =>
 							setSetting( 'chat_model', newValue )

--- a/tests/e2e/specs/dashboard.spec.js
+++ b/tests/e2e/specs/dashboard.spec.js
@@ -347,12 +347,9 @@ test.describe( 'Dashboard', () => {
 			.getByRole( 'button', { name: 'Assistant' } )
 			.click( { force: true } );
 
-		await page
-			.getByRole( 'radio', { name: 'GPT-4.1 nano' } )
-			.click( { force: true } );
-		await expect(
-			page.getByRole( 'radio', { name: 'GPT-4.1 nano' } )
-		).toBeChecked();
+		const modelSelect = page.getByRole( 'combobox', { name: 'Model' } );
+		await modelSelect.selectOption( 'gpt-5.4' );
+		await expect( modelSelect ).toHaveValue( 'gpt-5.4' );
 	} );
 
 	test( 'delete conversation/thread', async ( { page } ) => {

--- a/tests/php/unit/tests/test-openai-model.php
+++ b/tests/php/unit/tests/test-openai-model.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Tests for OpenAI chat model resolution.
+ *
+ * @package Codeinwp\HyveLite
+ */
+
+use ThemeIsle\HyveLite\OpenAI;
+
+/**
+ * Class Test_OpenAI_Model.
+ */
+class Test_OpenAI_Model extends WP_UnitTestCase {
+
+	/**
+	 * GPT-3.5 models fall back to the default.
+	 */
+	public function test_gpt35_falls_back_to_default() {
+		$this->assertEquals( 'gpt-4o-mini', OpenAI::resolve_chat_model( 'gpt-3.5-turbo-0125' ) );
+		$this->assertEquals( 'gpt-4o-mini', OpenAI::resolve_chat_model( 'gpt-3.5-turbo' ) );
+	}
+
+	/**
+	 * Empty or invalid values fall back to the default.
+	 */
+	public function test_empty_or_invalid_falls_back_to_default() {
+		$this->assertEquals( 'gpt-4o-mini', OpenAI::resolve_chat_model( '' ) );
+		$this->assertEquals( 'gpt-4o-mini', OpenAI::resolve_chat_model( null ) );
+		$this->assertEquals( 'gpt-4o-mini', OpenAI::resolve_chat_model( [] ) );
+	}
+
+	/**
+	 * Supported models are returned unchanged.
+	 */
+	public function test_supported_models_pass_through() {
+		foreach ( [ 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-4.1', 'gpt-4o-mini', 'gpt-4o' ] as $model ) {
+			$this->assertEquals( $model, OpenAI::resolve_chat_model( $model ) );
+		}
+	}
+}


### PR DESCRIPTION
Refreshes the selectable OpenAI models and removes GPT-3.5, which was broken.

## Problem
GPT-3.5 (`gpt-3.5-turbo-0125`) doesn't support the structured-output (`json_schema`) response format Hyve sends on every chat request, so selecting it produced `Invalid parameter: 'text.format' of type 'json_schema' is not supported…` and the chat failed 100% of the time.

## What changed
- **Added** the GPT-5.4 family: **GPT-5.4 / GPT-5.4 mini / GPT-5.4 nano**.
- **Kept** the existing **GPT-4.1 / GPT-4.1 mini / GPT-4.1 nano** and **GPT-4o / GPT-4o mini** (default unchanged).
- **Removed** GPT-3.5 (broken).
- **New compact UI:** the model picker is now a dropdown (`SelectControl`) instead of a tall radio list, showing the selected model's description as help text.

Every listed model was **verified against the live API** to support everything Hyve requires — structured outputs **and** the `temperature`/`top_p` controls. Reasoning-only models (GPT-5, GPT-5.5, the `o`-series, and every `-pro` tier) reject `temperature`/`top_p`, so they're intentionally excluded — adding them would reintroduce the same class of error.

## Backwards compatibility
- `OpenAI::resolve_chat_model()` maps any stored GPT-3.5 value to the default (GPT-4o mini) at request time, so existing sites keep working with no manual change.
- The picker preserves a still-valid but no-longer-listed saved model (e.g. an older snapshot) as an extra option, so an existing selection isn't silently dropped.

## Tests
`tests/php/unit/tests/test-openai-model.php` covers the fallback: GPT-3.5 / empty / invalid → GPT-4o mini, and supported models pass through unchanged.

## QA
1. Hyve → Settings → Assistant: the Model field is a dropdown listing the GPT-5.4 family, GPT-4.1 family, and GPT-4o family — no GPT-3.5. The selected model's description shows below it.
2. On a site previously set to GPT-3.5, the chat works (uses GPT-4o mini) and the picker shows GPT-4o mini selected.
3. Pick GPT-5.4 (and the mini/nano), send a chat message on the frontend — a normal answer returns, no `text.format`/parameter error.

Closes Codeinwp/hyve#221
