### PR TITLE
feat: support private and password-protected content in the Knowledge Base

### DIFF
--- a/inc/API.php
+++ b/inc/API.php
@@ -434,6 +434,29 @@ class API extends BaseAPI {
 	}
 
 	/**
+	 * Get the visibility of a post for the Knowledge Base UI.
+	 *
+	 * Content added to the Knowledge Base is surfaced to any chat visitor
+	 * regardless of the post's original visibility, so the admin UI flags
+	 * restricted content.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return string One of 'public', 'private' or 'password'.
+	 */
+	private function get_post_visibility( $post_id ) {
+		if ( 'private' === get_post_status( $post_id ) ) {
+			return 'private';
+		}
+
+		if ( '' !== get_post_field( 'post_password', $post_id ) ) {
+			return 'password';
+		}
+
+		return 'public';
+	}
+
+	/**
 	 * Get data.
 	 *
 	 * @param \WP_REST_Request<array<string, mixed>> $request Request object.
@@ -443,7 +466,7 @@ class API extends BaseAPI {
 	public function get_data( $request ) {
 		$args = [
 			'post_type'      => $request->get_param( 'type' ),
-			'post_status'    => 'publish',
+			'post_status'    => [ 'publish', 'private' ],
 			'posts_per_page' => 20,
 			'fields'         => 'ids',
 			'offset'         => $request->get_param( 'offset' ),
@@ -519,8 +542,9 @@ class API extends BaseAPI {
 				 * @var int $post_id
 				 */
 				$post_data = [
-					'ID'    => $post_id,
-					'title' => get_the_title( $post_id ),
+					'ID'         => $post_id,
+					'title'      => get_the_title( $post_id ),
+					'visibility' => $this->get_post_visibility( $post_id ),
 				];
 
 				if ( 'moderation' === $status ) {

--- a/inc/DB_Table.php
+++ b/inc/DB_Table.php
@@ -597,7 +597,7 @@ class DB_Table {
 	public function update_posts() {
 		$args = [
 			'post_type'      => 'any',
-			'post_status'    => 'publish',
+			'post_status'    => [ 'publish', 'private' ],
 			'posts_per_page' => 5,
 			'fields'         => 'ids',
 			'meta_query'     => [

--- a/src/backend/parts/data/AddData.js
+++ b/src/backend/parts/data/AddData.js
@@ -12,6 +12,7 @@ import apiFetch from '@wordpress/api-fetch';
 
 import {
 	Button,
+	Modal,
 	Notice,
 	Panel,
 	PanelRow,
@@ -53,6 +54,7 @@ const AddData = ( { refresh, setAddPost } ) => {
 	const [ isUpdating, setUpdating ] = useState( [] );
 	const [ isModerationModalOpen, setModerationModalOpen ] = useState( false );
 	const [ post, setPost ] = useState( null );
+	const [ confirmPost, setConfirmPost ] = useState( null );
 	const [ offset, setOffset ] = useState( 0 );
 
 	const [ query, setQuery ] = useState( {
@@ -66,7 +68,20 @@ const AddData = ( { refresh, setAddPost } ) => {
 		select( 'hyve' ).hasReachedLimit()
 	);
 
-	const onProcess = async ( id ) => {
+	const onProcess = ( id ) => {
+		const currentPost = posts[ queryHash ]?.find( ( p ) => p.ID === id );
+
+		// Restricted content is surfaced to any chat visitor once added, so
+		// require an explicit confirmation before importing it.
+		if ( currentPost && 'public' !== currentPost.visibility ) {
+			setConfirmPost( currentPost );
+			return;
+		}
+
+		processPost( id );
+	};
+
+	const processPost = async ( id ) => {
 		setUpdating( ( prev ) => [ ...prev, id ] );
 		const currentPost = posts[ queryHash ].find( ( p ) => p.ID === id );
 
@@ -227,6 +242,45 @@ const AddData = ( { refresh, setAddPost } ) => {
 					</PanelRow>
 				</Panel>
 			</div>
+
+			{ confirmPost && (
+				<Modal
+					title={ __( 'Add restricted content?', 'hyve-lite' ) }
+					onRequestClose={ () => setConfirmPost( null ) }
+				>
+					<p className="max-w-md">
+						{ 'private' === confirmPost.visibility
+							? __(
+									'This is a private post. Adding it to the Knowledge Base lets the chatbot surface its content to any visitor, even though the post itself is not publicly viewable.',
+									'hyve-lite'
+							  )
+							: __(
+									'This is a password-protected post. Adding it to the Knowledge Base lets the chatbot surface its content to any visitor without entering the password.',
+									'hyve-lite'
+							  ) }
+					</p>
+
+					<div className="flex justify-end gap-3 pt-6">
+						<Button
+							variant="tertiary"
+							onClick={ () => setConfirmPost( null ) }
+						>
+							{ __( 'Cancel', 'hyve-lite' ) }
+						</Button>
+
+						<Button
+							variant="primary"
+							onClick={ () => {
+								const id = confirmPost.ID;
+								setConfirmPost( null );
+								processPost( id );
+							} }
+						>
+							{ __( 'Add anyway', 'hyve-lite' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
 
 			<ModerationReview
 				post={ post }

--- a/tests/e2e/specs/knowledge-base-visibility.spec.js
+++ b/tests/e2e/specs/knowledge-base-visibility.spec.js
@@ -1,0 +1,178 @@
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import { HYVE_DATA_API_ROUTE_PATTERN } from '../utils';
+
+/**
+ * Posts returned by the mocked Add Data listing, one per visibility type.
+ * Order matters: the per-row "Add" buttons are matched by index below.
+ */
+const MOCK_POSTS = [
+	{ ID: 201, title: 'Pickleball Rules', visibility: 'public' },
+	{ ID: 202, title: 'Internal Refund Policy', visibility: 'private' },
+	{ ID: 203, title: 'Partner Discount Codes', visibility: 'password' },
+];
+
+/**
+ * Mock the Add Data listing and capture any add (POST) requests.
+ *
+ * @param {import("@playwright/test").Page} page  The page.
+ * @param {number[]}                        added IDs of posts that were sent to be added.
+ */
+async function mockAddData( page, added ) {
+	await page.route( HYVE_DATA_API_ROUTE_PATTERN, async ( route ) => {
+		const request = route.request();
+
+		// An add action: record the post ID and report success.
+		if ( 'POST' === request.method() ) {
+			const body = request.postDataJSON();
+			added.push( body?.data?.ID );
+
+			await route.fulfill( {
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify( true ),
+			} );
+			return;
+		}
+
+		const url = request.url();
+
+		// The Add Data listing fetch (no status filter).
+		if ( url.includes( 'offset=0' ) && ! url.includes( 'status=' ) ) {
+			await route.fulfill( {
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify( {
+					posts: MOCK_POSTS,
+					more: false,
+					totalChunks: '0',
+				} ),
+			} );
+			return;
+		}
+
+		await route.continue();
+	} );
+}
+
+/**
+ * Open Knowledge Base → WordPress Import → Add Posts.
+ *
+ * @param {import("@playwright/test").Page}                      page  The page.
+ * @param {import("@wordpress/e2e-test-utils-playwright").Admin} admin The admin utils.
+ */
+async function openAddData( page, admin ) {
+	await admin.visitAdminPage( 'admin.php?page=hyve' );
+
+	await page
+		.getByRole( 'button', { name: 'Knowledge Base', exact: true } )
+		.click( { force: true } );
+	await page
+		.getByRole( 'button', { name: 'WordPress → Import your' } )
+		.click( { force: true } );
+	await page
+		.getByRole( 'button', { name: 'Add Posts' } )
+		.click( { force: true } );
+
+	// Wait for the (debounced) listing to render.
+	await expect( page.getByText( 'Pickleball Rules' ) ).toBeVisible();
+}
+
+test.describe( 'Knowledge Base — private/password content', () => {
+	test( 'public post is added without confirmation', async ( {
+		page,
+		admin,
+	} ) => {
+		const added = [];
+		await mockAddData( page, added );
+		await openAddData( page, admin );
+
+		await page
+			.getByRole( 'button', { name: 'Add', exact: true } )
+			.nth( 0 )
+			.click( { force: true } );
+
+		// No confirmation dialog for public content.
+		await expect(
+			page.getByRole( 'heading', { name: 'Add restricted content?' } )
+		).toBeHidden();
+
+		// The add request went through.
+		await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+		expect( added ).toEqual( [ 201 ] );
+	} );
+
+	test( 'private post asks for confirmation and Cancel aborts', async ( {
+		page,
+		admin,
+	} ) => {
+		const added = [];
+		await mockAddData( page, added );
+		await openAddData( page, admin );
+
+		await page
+			.getByRole( 'button', { name: 'Add', exact: true } )
+			.nth( 1 )
+			.click( { force: true } );
+
+		// The confirmation dialog explains the private-content exposure.
+		await expect(
+			page.getByRole( 'heading', { name: 'Add restricted content?' } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'This is a private post.' )
+		).toBeVisible();
+
+		await page
+			.getByRole( 'button', { name: 'Cancel' } )
+			.click( { force: true } );
+
+		await expect(
+			page.getByRole( 'heading', { name: 'Add restricted content?' } )
+		).toBeHidden();
+
+		// Nothing was added.
+		expect( added ).toEqual( [] );
+	} );
+
+	test( 'private post is added after confirming', async ( {
+		page,
+		admin,
+	} ) => {
+		const added = [];
+		await mockAddData( page, added );
+		await openAddData( page, admin );
+
+		await page
+			.getByRole( 'button', { name: 'Add', exact: true } )
+			.nth( 1 )
+			.click( { force: true } );
+
+		await page
+			.getByRole( 'button', { name: 'Add anyway' } )
+			.click( { force: true } );
+
+		await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+		expect( added ).toEqual( [ 202 ] );
+	} );
+
+	test( 'password-protected post shows a password-specific warning', async ( {
+		page,
+		admin,
+	} ) => {
+		const added = [];
+		await mockAddData( page, added );
+		await openAddData( page, admin );
+
+		await page
+			.getByRole( 'button', { name: 'Add', exact: true } )
+			.nth( 2 )
+			.click( { force: true } );
+
+		await expect(
+			page.getByRole( 'heading', { name: 'Add restricted content?' } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'This is a password-protected post.' )
+		).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
## Description

Private and password-protected posts can now be added to the Knowledge Base.

Previously the Add Data listing only queried published content, so **private** posts were excluded. (Password-protected posts keep the `publish` status, so they already matched and were addable.)

Because anything added to the Knowledge Base is surfaced to any chat visitor regardless of the post's original visibility, adding a private or password-protected post now requires an explicit confirmation.

### Changes

- The Add Data listing includes `private` posts (the endpoint is admin-only).
- The re-index cron also includes `private` posts so they stay in sync when edited.
- A confirmation dialog is shown before adding private/password-protected content, explaining that it will be exposed through chat.

## Screenshot

<img width="1184" height="816" alt="Screenshot 2026-07-01 at 3 45 14 AM" src="https://github.com/user-attachments/assets/bb4e3148-9276-4a47-ad09-4d8e4924e15b" />

## QA

1. Create three posts/pages with different visibility:
   - a normal **Published** post,
   - a **Private** post,
   - a **Password protected** post.
2. Go to **Hyve → Knowledge Base → WordPress → Add Posts**.
3. Confirm the private and password-protected posts now appear in the list (WordPress shows "Private:" / "Protected:" prefixes on their titles).
4. Click **Add** on the normal post → it is added directly, with no prompt.
5. Click **Add** on the **private** post → an "Add restricted content?" dialog appears explaining the exposure.
   - Click **Cancel** → nothing is added.
   - Click **Add** again, then **Add anyway** → the post is added.
6. Repeat step 5 for the **password-protected** post and confirm the dialog mentions the password.
7. Edit a private post that is already in the Knowledge Base, then confirm its content gets re-indexed (the updated content is reflected).

Closes: https://github.com/Codeinwp/hyve/issues/175
