### PR TITLE
feat: control chat visibility from the dashboard

### DIFF
--- a/hyve-lite.php
+++ b/hyve-lite.php
@@ -60,9 +60,16 @@ add_filter(
 	}
 );
 
+add_filter(
+	HYVE_PRODUCT_SLUG . '_sdk_migrations_path',
+	function () {
+		return HYVE_LITE_PATH . '/migrations';
+	}
+);
+
 add_action(
 	'plugins_loaded',
 	function () {
 		new \ThemeIsle\HyveLite\Main();
-	} 
+	}
 );

--- a/inc/API.php
+++ b/inc/API.php
@@ -316,11 +316,38 @@ class API extends BaseAPI {
 					},
 					'sanitize' => 'sanitize_url',
 				],
-				'chat_enabled'               => [
+				'display_mode'               => [
 					'validate' => function ( $value ) {
-						return is_bool( $value );
+						return in_array( $value, [ 'all', 'include', 'exclude', 'manual' ], true );
 					},
-					'sanitize' => 'rest_sanitize_boolean',
+					'sanitize' => 'sanitize_text_field',
+				],
+				'display_rules'              => [
+					'validate' => function ( $value ) {
+						return is_array( $value );
+					},
+					'sanitize' => function ( $value ) {
+						if ( ! is_array( $value ) ) {
+							return [];
+						}
+
+						$rules = [];
+
+						foreach ( $value as $rule ) {
+							if ( ! is_array( $rule ) || empty( $rule['path'] ) ) {
+								continue;
+							}
+
+							$operator = ( isset( $rule['operator'] ) && 'matches' === $rule['operator'] ) ? 'matches' : 'contains';
+
+							$rules[] = [
+								'path'     => sanitize_text_field( $rule['path'] ),
+								'operator' => $operator,
+							];
+						}
+
+						return $rules;
+					},
 				],
 				'welcome_message'            => [
 					'validate' => function ( $value ) {

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -232,7 +232,6 @@ class Main {
 				'api_key'                    => '',
 				'qdrant_api_key'             => '',
 				'qdrant_endpoint'            => '',
-				'chat_enabled'               => true,
 				'chat_model'                 => 'gpt-4o-mini',
 				'temperature'                => 1,
 				'top_p'                      => 1,
@@ -253,6 +252,8 @@ class Main {
 				'default_message'            => '',
 				'similarity_score_threshold' => 0.4,
 				'post_row_addon_enabled'     => true,
+				'display_mode'               => 'all',
+				'display_rules'              => [],
 			]
 		);
 	}
@@ -265,11 +266,28 @@ class Main {
 	 * @return array<string, mixed>
 	 */
 	public static function get_settings() {
-		$settings = get_option( 'hyve_settings', [] );
+		$saved = get_option( 'hyve_settings', [] );
 
+		if ( ! is_array( $saved ) ) {
+			$saved = [];
+		}
+
+		$settings                      = $saved;
 		$settings['telemetry_enabled'] = 'yes' === get_option( 'hyve_lite_logger_flag', 'no' );
 
-		return wp_parse_args( $settings, self::get_default_settings() );
+		$settings = wp_parse_args( $settings, self::get_default_settings() );
+
+		/*
+		 * Backward compatibility: derive the visibility mode from the legacy
+		 * chat_enabled boolean until the migration persists display_mode. Only
+		 * fires on the front-end window before the SDK migration runs (admin_init
+		 * after an upgrade), so it can be removed once all installs migrated.
+		 */
+		if ( ! isset( $saved['display_mode'] ) ) {
+			$settings['display_mode'] = ( isset( $saved['chat_enabled'] ) && ! $saved['chat_enabled'] ) ? 'manual' : 'all';
+		}
+
+		return $settings;
 	}
 
 	/**
@@ -342,6 +360,8 @@ class Main {
 		 */
 		$should_show_chat = apply_filters( 'hyve_display_chat', 0 < intval( $stats['totalChunks'] ) );
 
+		$should_display_chat = $this->should_display_chat();
+
 		wp_localize_script(
 			'hyve-lite-scripts',
 			'hyveClient',
@@ -354,7 +374,7 @@ class Main {
 						'ping'  => HYVE_LITE_URL . 'assets/audio/ping.mp3',
 					],
 					'welcome'   => esc_html( $settings['welcome_message'] ?? '' ),
-					'isEnabled' => $settings['chat_enabled'],
+					'isEnabled' => $should_display_chat,
 					'strings'   => [
 						'reply'             => __( 'Write a reply…', 'hyve-lite' ),
 						'suggestions'       => __( 'Not sure where to start?', 'hyve-lite' ),
@@ -377,7 +397,7 @@ class Main {
 			)
 		);
 
-		if ( ! isset( $settings['chat_enabled'] ) || false === $settings['chat_enabled'] ) {
+		if ( ! $should_display_chat ) {
 			return;
 		}
 
@@ -516,11 +536,76 @@ class Main {
 	 */
 	public function is_global_chat_enabled() {
 		$settings = self::get_settings();
-		if ( ! isset( $settings['chat_enabled'] ) ) {
+
+		return isset( $settings['display_mode'] ) && 'all' === $settings['display_mode'];
+	}
+
+	/**
+	 * Whether the chat should be auto-displayed on the current request.
+	 *
+	 * Evaluates the visibility rules against the current page. Manual placement
+	 * via the block or shortcode is unaffected by this.
+	 *
+	 * @since 1.4.2
+	 *
+	 * @return bool
+	 */
+	public function should_display_chat() {
+		$settings = self::get_settings();
+		$mode     = isset( $settings['display_mode'] ) ? $settings['display_mode'] : 'all';
+
+		if ( 'all' === $mode ) {
+			return true;
+		}
+
+		if ( 'include' !== $mode && 'exclude' !== $mode ) {
+			// 'manual' or any unknown mode: no automatic display.
 			return false;
 		}
 
-		return boolval( $settings['chat_enabled'] );
+		$rules   = ( isset( $settings['display_rules'] ) && is_array( $settings['display_rules'] ) ) ? $settings['display_rules'] : [];
+		$matches = $this->path_matches( $rules );
+
+		return 'include' === $mode ? $matches : ! $matches;
+	}
+
+	/**
+	 * Check the current request URI against a set of path rules.
+	 *
+	 * Mirrors the exact/contains matching used by other ThemeIsle plugins.
+	 *
+	 * @since 1.4.2
+	 *
+	 * @param array<int, array<string, string>> $rules List of { path, operator } rules.
+	 *
+	 * @return bool True when any rule matches the current request.
+	 */
+	private function path_matches( $rules ) {
+		if ( empty( $rules ) || ! isset( $_SERVER['REQUEST_URI'] ) ) {
+			return false;
+		}
+
+		$uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+
+		foreach ( $rules as $rule ) {
+			$path = isset( $rule['path'] ) ? trim( $rule['path'] ) : '';
+
+			if ( '' === $path ) {
+				continue;
+			}
+
+			$operator = isset( $rule['operator'] ) ? $rule['operator'] : 'contains';
+
+			if ( 'matches' === $operator ) {
+				if ( $uri === $path ) {
+					return true;
+				}
+			} elseif ( false !== strpos( $uri, $path ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -701,7 +786,8 @@ class Main {
 				'stats_threads'             => $options['stats']['threads'],
 				'stats_total_chunks'        => $options['stats']['totalChunks'],
 				'openai_chat_model'         => $settings['chat_model'],
-				'chat_on_all_pages_enabled' => $settings['chat_enabled'],
+				'chat_on_all_pages_enabled' => 'all' === $settings['display_mode'],
+				'chat_display_mode'         => $settings['display_mode'],
 			],
 		];
 

--- a/migrations/20260703120000_migrate_chat_display_mode.php
+++ b/migrations/20260703120000_migrate_chat_display_mode.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Migrate the legacy `chat_enabled` flag to the `display_mode` setting.
+ *
+ * @package Codeinwp\HyveLite
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+return new class() extends \ThemeisleSDK\Modules\Abstract_Migration {
+
+	/**
+	 * Only run until the new setting has been persisted.
+	 *
+	 * @return bool
+	 */
+	public function should_run() {
+		$settings = get_option( 'hyve_settings', [] );
+
+		return is_array( $settings ) && ! isset( $settings['display_mode'] );
+	}
+
+	/**
+	 * Persist display_mode derived from the legacy chat_enabled flag.
+	 *
+	 * A previously disabled chat becomes "manual" (block/shortcode only);
+	 * everything else defaults to showing on all pages.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		$settings = get_option( 'hyve_settings', [] );
+
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
+
+		$settings['display_mode'] = ( isset( $settings['chat_enabled'] ) && ! $settings['chat_enabled'] ) ? 'manual' : 'all';
+
+		update_option( 'hyve_settings', $settings );
+	}
+};

--- a/src/backend/parts/Home.js
+++ b/src/backend/parts/Home.js
@@ -6,10 +6,9 @@ import { __ } from '@wordpress/i18n';
 import {
 	Button,
 	Panel,
-	PanelRow, // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	PanelRow,
+	SelectControl,
+	TextControl,
 } from '@wordpress/components';
 
 import apiFetch from '@wordpress/api-fetch';
@@ -21,7 +20,20 @@ import { UsageCharts } from '../components/UsageChart';
 
 const { setRoute: changeRoute } = dispatch( 'hyve' );
 
-import { useState, useCallback, useEffect } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
+
+const DISPLAY_MODE_OPTIONS = [
+	{ label: __( 'Show on all pages', 'hyve-lite' ), value: 'all' },
+	{
+		label: __( 'Show only on selected content', 'hyve-lite' ),
+		value: 'include',
+	},
+	{
+		label: __( 'Show everywhere except selected content', 'hyve-lite' ),
+		value: 'exclude',
+	},
+	{ label: __( "Don't show automatically", 'hyve-lite' ), value: 'manual' },
+];
 
 const STATUS = [
 	{
@@ -62,9 +74,44 @@ const Dashboard = ( { isBlocked } ) => {
 	const { setSetting } = useDispatch( 'hyve' );
 	const { createNotice } = useDispatch( 'core/notices' );
 
-	const [ autoUpdate, setAutoUpdate ] = useState( false );
+	const [ isSavingVisibility, setSavingVisibility ] = useState( false );
+	const [ visibilitySaved, setVisibilitySaved ] = useState( false );
 
-	const onSave = useCallback( async () => {
+	const displayMode = settings.display_mode ?? 'all';
+	const displayRules = settings.display_rules ?? [];
+
+	const updateVisibility = ( key, value ) => {
+		setVisibilitySaved( false );
+		setSetting( key, value );
+	};
+
+	const updateRule = ( index, key, value ) => {
+		updateVisibility(
+			'display_rules',
+			displayRules.map( ( rule, i ) =>
+				i === index ? { ...rule, [ key ]: value } : rule
+			)
+		);
+	};
+
+	const addRule = () => {
+		updateVisibility( 'display_rules', [
+			...displayRules,
+			{ path: '', operator: 'contains' },
+		] );
+	};
+
+	const removeRule = ( index ) => {
+		updateVisibility(
+			'display_rules',
+			displayRules.filter( ( _, i ) => i !== index )
+		);
+	};
+
+	const saveVisibility = useCallback( async () => {
+		setSavingVisibility( true );
+		setVisibilitySaved( false );
+
 		try {
 			const response = await apiFetch( {
 				path: `${ window.hyve.api }/settings`,
@@ -78,24 +125,16 @@ const Dashboard = ( { isBlocked } ) => {
 				throw new Error( response.error );
 			}
 
-			createNotice( 'success', __( 'Settings saved.', 'hyve-lite' ), {
-				type: 'snackbar',
-				isDismissible: true,
-			} );
+			setVisibilitySaved( true );
 		} catch ( error ) {
 			createNotice( 'error', error, {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
 		}
-	}, [ settings, createNotice ] );
 
-	useEffect( () => {
-		if ( autoUpdate ) {
-			onSave();
-			setAutoUpdate( false );
-		}
-	}, [ autoUpdate, onSave ] );
+		setSavingVisibility( false );
+	}, [ settings, createNotice ] );
 
 	const ACTIONS = [
 		{
@@ -134,43 +173,175 @@ const Dashboard = ( { isBlocked } ) => {
 		<div className="col-span-6 xl:col-span-4">
 			<Panel header={ __( 'Dashboard', 'hyve-lite' ) }>
 				<PanelRow>
-					<ToggleGroupControl
-						__nextHasNoMarginBottom
-						isBlock
-						label={ __(
-							'Enable Chat on all the pages',
-							'hyve-lite'
+					<div className="mb-6">
+						<p className="text-sm font-semibold mb-1">
+							{ __( 'Where should Hyve appear?', 'hyve-lite' ) }
+						</p>
+						<p className="text-sm text-gray-500 mb-3">
+							{ __(
+								'Blocks and shortcodes remain available for inline or manual placement.',
+								'hyve-lite'
+							) }
+						</p>
+
+						<div
+							role="radiogroup"
+							aria-label={ __(
+								'Where should Hyve appear?',
+								'hyve-lite'
+							) }
+							className="flex flex-wrap gap-3"
+						>
+							{ DISPLAY_MODE_OPTIONS.map( ( option ) => {
+								const isSelected = displayMode === option.value;
+
+								return (
+									<label
+										key={ option.value }
+										htmlFor={ `hyve-mode-${ option.value }` }
+										className={ `inline-flex items-center gap-2.5 m-0 px-4 py-3 border border-solid rounded-md cursor-pointer transition-colors duration-100 ${
+											isSelected
+												? 'border-[#3858e9] bg-[#f0f3ff]'
+												: 'border-gray-300 bg-white hover:border-gray-400'
+										}` }
+									>
+										<input
+											type="radio"
+											id={ `hyve-mode-${ option.value }` }
+											name="hyve-display-mode"
+											className="w-5 h-5 shrink-0 cursor-pointer accent-[#3858e9]"
+											aria-label={ option.label }
+											value={ option.value }
+											checked={ isSelected }
+											onChange={ () =>
+												updateVisibility(
+													'display_mode',
+													option.value
+												)
+											}
+										/>
+										<span className="text-sm font-medium text-gray-900 whitespace-nowrap">
+											{ option.label }
+										</span>
+									</label>
+								);
+							} ) }
+						</div>
+
+						{ ( 'include' === displayMode ||
+							'exclude' === displayMode ) && (
+							<div className="mt-4 p-4 border border-solid border-gray-200 rounded-md">
+								<p className="text-sm font-medium mb-1">
+									{ __( 'Content URLs', 'hyve-lite' ) }
+								</p>
+								<p className="text-xs text-gray-500 mb-3">
+									{ __(
+										'Match by URL path. Use “contains” for a whole section (e.g. /shop/), or “matches” for one exact page.',
+										'hyve-lite'
+									) }
+								</p>
+
+								{ displayRules.map( ( rule, index ) => (
+									<div
+										// eslint-disable-next-line react/no-array-index-key
+										key={ index }
+										className="flex gap-2 items-end mb-2"
+									>
+										<div className="flex-1">
+											<TextControl
+												__nextHasNoMarginBottom
+												hideLabelFromVision
+												label={ __(
+													'Path',
+													'hyve-lite'
+												) }
+												placeholder={ __(
+													'/example-page/',
+													'hyve-lite'
+												) }
+												value={ rule.path || '' }
+												onChange={ ( value ) =>
+													updateRule(
+														index,
+														'path',
+														value
+													)
+												}
+											/>
+										</div>
+
+										<div className="w-36">
+											<SelectControl
+												__nextHasNoMarginBottom
+												hideLabelFromVision
+												label={ __(
+													'Operator',
+													'hyve-lite'
+												) }
+												value={
+													rule.operator || 'contains'
+												}
+												options={ [
+													{
+														label: __(
+															'contains',
+															'hyve-lite'
+														),
+														value: 'contains',
+													},
+													{
+														label: __(
+															'matches',
+															'hyve-lite'
+														),
+														value: 'matches',
+													},
+												] }
+												onChange={ ( value ) =>
+													updateRule(
+														index,
+														'operator',
+														value
+													)
+												}
+											/>
+										</div>
+
+										<Button
+											variant="tertiary"
+											isDestructive
+											onClick={ () =>
+												removeRule( index )
+											}
+										>
+											{ __( 'Remove', 'hyve-lite' ) }
+										</Button>
+									</div>
+								) ) }
+
+								<Button variant="secondary" onClick={ addRule }>
+									{ __( 'Add URL Rule', 'hyve-lite' ) }
+								</Button>
+							</div>
 						) }
-						value={ Boolean( settings.chat_enabled ) }
-						onChange={ ( newValue ) => {
-							setSetting( 'chat_enabled', Boolean( newValue ) );
-							setAutoUpdate( true );
-						} }
-						help={
-							__(
-								'Display the Chat on all the pages.',
-								'hyve-lite'
-							) +
-							' ' +
-							__(
-								'For specific pages, use the Hyve Gutenberg Block.',
-								'hyve-lite'
-							)
-						}
-					>
-						<ToggleGroupControlOption
-							aria-label={ __( 'Enable Chat', 'hyve-lite' ) }
-							label={ __( 'Enable', 'hyve-lite' ) }
-							showTooltip
-							value={ true }
-						/>
-						<ToggleGroupControlOption
-							aria-label={ __( 'Enable Chat', 'hyve-lite' ) }
-							label={ __( 'Disable', 'hyve-lite' ) }
-							showTooltip
-							value={ false }
-						/>
-					</ToggleGroupControl>
+
+						<div className="flex items-center gap-3 mt-4">
+							<Button
+								variant="primary"
+								onClick={ saveVisibility }
+								isBusy={ isSavingVisibility }
+								disabled={ isSavingVisibility }
+							>
+								{ __( 'Save visibility', 'hyve-lite' ) }
+							</Button>
+
+							{ visibilitySaved && (
+								<span className="text-sm text-gray-500">
+									{ __( 'Saved.', 'hyve-lite' ) }
+								</span>
+							) }
+						</div>
+					</div>
 
 					{ 0 ===
 						Number( window.hyve?.stats?.totalChunks ?? '0' ) && (

--- a/src/block/index.js
+++ b/src/block/index.js
@@ -21,9 +21,7 @@ registerBlockType( metadata.name, {
 
 		const isKnowledgeBaseEmpty =
 			0 === Number( window.hyveChatBlock.stats.totalChunks ?? '0' );
-		const isBlockIgnored = Boolean(
-			window.hyveChatBlock?.globalChatEnabled
-		);
+		const isGlobalChat = Boolean( window.hyveChatBlock?.globalChatEnabled );
 		const isFloatingVariant = 'floating' === attributes?.variant;
 		let placeholderText = __(
 			'Hyve Chatbot will appear here. No further action needed.',
@@ -71,35 +69,27 @@ registerBlockType( metadata.name, {
 							</p>
 						</Notice>
 					) }
-					{ isBlockIgnored ? (
-						<div
-							style={ {
-								display: 'flex',
-								flexDirection: 'column',
-								alignItems: 'flex-start',
-								gap: '1rem',
-							} }
-						>
-							{ __(
-								'The Hyve Chat is enabled on all pages, and it won’t appear here to avoid conflicts.',
-								'hyve-lite'
-							) }
-							<Button
-								variant="secondary"
-								onClick={ ( event ) => {
-									event.preventDefault();
-									window.open(
-										window.hyveChatBlock.dashboardURL,
-										'_blank'
-									);
-								} }
-							>
-								{ __( 'Go to Dashboard', 'hyve-lite' ) }
-							</Button>
-						</div>
-					) : (
-						placeholderText
+					{ isGlobalChat && ! isFloatingVariant && (
+						<Notice isDismissible={ false } status="info">
+							<p>
+								{ __(
+									'Hyve Chat is set to appear on all pages. This inline block will be shown here in place of the floating bubble.',
+									'hyve-lite'
+								) }
+							</p>
+						</Notice>
 					) }
+					{ isGlobalChat && isFloatingVariant && (
+						<Notice isDismissible={ false } status="info">
+							<p>
+								{ __(
+									'Hyve Chat already appears on all pages, so this floating block is not needed here.',
+									'hyve-lite'
+								) }
+							</p>
+						</Notice>
+					) }
+					{ placeholderText }
 				</Placeholder>
 			</div>
 		);

--- a/src/frontend/App.js
+++ b/src/frontend/App.js
@@ -20,6 +20,7 @@ class App {
 		this.runID = null;
 		this.recordID = null;
 		this.isMenuOpen = false;
+		this.isInline = false;
 
 		if ( Boolean( window.hyveClient?.canShow ) ) {
 			this.initialize();
@@ -31,6 +32,30 @@ class App {
 		await this.renderUI();
 		this.setupListeners();
 		this.restoreMessages();
+		this.showInlineWelcome();
+	}
+
+	/**
+	 * Show the welcome message for an inline placement.
+	 *
+	 * The inline chat is always open, so it never goes through
+	 * toggleChatWindow() where the floating chat adds its welcome message.
+	 */
+	showInlineWelcome() {
+		if ( ! this.isInline || 0 !== this.messages.length ) {
+			return;
+		}
+
+		if ( ! window.hyveClient.welcome || '' === window.hyveClient.welcome ) {
+			return;
+		}
+
+		this.isInitialToggle = false;
+
+		setTimeout( () => {
+			this.add( window.hyveClient.welcome, 'bot' );
+			this.addSuggestions();
+		}, 1000 );
 	}
 
 	restoreStorage() {
@@ -741,9 +766,16 @@ class App {
 		chatInputBox.appendChild( chatSendButton );
 		chatWindow.appendChild( chatInputBox );
 
+		// An explicit inline placement (block or shortcode) always wins over the
+		// floating auto-display, so the chat renders where it was added regardless
+		// of the global visibility rules.
+		const inlineChat = document.querySelector( '#hyve-inline-chat' );
 		const chatExists = document.querySelectorAll( '#hyve-chat' );
 
-		if (
+		if ( inlineChat ) {
+			inlineChat.appendChild( chatWindow );
+			this.isInline = true;
+		} else if (
 			true === Boolean( window?.hyveClient?.isEnabled ) ||
 			0 < chatExists.length
 		) {
@@ -754,14 +786,6 @@ class App {
 			document.body.appendChild( chatWindow );
 			document.body.appendChild( chatOpen );
 			document.body.appendChild( chatClose );
-
-			return;
-		}
-
-		const inlineChat = document.querySelector( '#hyve-inline-chat' );
-
-		if ( inlineChat ) {
-			inlineChat.appendChild( chatWindow );
 		}
 	}
 

--- a/tests/e2e/specs/chat-visibility.spec.js
+++ b/tests/e2e/specs/chat-visibility.spec.js
@@ -1,0 +1,71 @@
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+const HYVE_SETTINGS_ROUTE_PATTERN =
+	/.*(?:rest_route=%2Fhyve%2Fv1%2Fsettings|\/wp-json\/hyve\/v1\/settings).*/;
+
+test.describe( 'Chat visibility', () => {
+	test( 'select a mode, add a URL rule and save', async ( {
+		page,
+		admin,
+	} ) => {
+		let savedData = null;
+
+		await page.route( HYVE_SETTINGS_ROUTE_PATTERN, async ( route ) => {
+			const request = route.request();
+
+			if ( 'POST' === request.method() ) {
+				savedData = request.postDataJSON();
+				await route.fulfill( {
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify( true ),
+				} );
+				return;
+			}
+
+			await route.continue();
+		} );
+
+		await admin.visitAdminPage( 'admin.php?page=hyve' );
+
+		// The visibility control renders.
+		await expect(
+			page.getByText( 'Where should Hyve appear?' )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'radio', { name: 'Show on all pages' } )
+		).toBeVisible();
+
+		// The URL box only shows for include/exclude modes.
+		await expect( page.getByText( 'Content URLs' ) ).toBeHidden();
+
+		await page
+			.getByRole( 'radio', { name: 'Show only on selected content' } )
+			.check();
+
+		await expect( page.getByText( 'Content URLs' ) ).toBeVisible();
+
+		// Add and fill a URL rule.
+		await page.getByRole( 'button', { name: 'Add URL rule' } ).click();
+		await page.getByPlaceholder( '/example-page/' ).fill( '/shop/' );
+
+		// Save and confirm the payload.
+		await page.getByRole( 'button', { name: 'Save visibility' } ).click();
+		await expect(
+			page.getByText( 'Saved.', { exact: true } )
+		).toBeVisible();
+
+		expect( savedData?.data?.display_mode ).toBe( 'include' );
+		expect( savedData?.data?.display_rules?.[ 0 ]?.path ).toBe( '/shop/' );
+	} );
+
+	test( 'manual mode hides the URL box', async ( { page, admin } ) => {
+		await admin.visitAdminPage( 'admin.php?page=hyve' );
+
+		await page
+			.getByRole( 'radio', { name: /show automatically/i } )
+			.check();
+
+		await expect( page.getByText( 'Content URLs' ) ).toBeHidden();
+	} );
+} );

--- a/tests/e2e/specs/dashboard.spec.js
+++ b/tests/e2e/specs/dashboard.spec.js
@@ -41,7 +41,7 @@ test.describe( 'Dashboard', () => {
 	 */
 	test( 'check tabs', async ( { page } ) => {
 		await expect(
-			page.getByText( 'Enable Chat on all the pages' )
+			page.getByText( 'Where should Hyve appear?' )
 		).toBeVisible();
 
 		await page

--- a/tests/php/unit/tests/test-visibility.php
+++ b/tests/php/unit/tests/test-visibility.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Tests for chat visibility rules.
+ *
+ * @package Codeinwp\HyveLite
+ */
+
+use ThemeIsle\HyveLite\Main;
+
+/**
+ * Class VisibilityTest
+ */
+class VisibilityTest extends WP_UnitTestCase {
+
+	/**
+	 * Main instance.
+	 *
+	 * @var Main
+	 */
+	private $main;
+
+	/**
+	 * Set up.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->main = new Main();
+	}
+
+	/**
+	 * Clean up.
+	 */
+	protected function tearDown(): void {
+		delete_option( 'hyve_settings' );
+		unset( $_SERVER['REQUEST_URI'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Store raw settings.
+	 *
+	 * @param array<string, mixed> $settings Settings.
+	 */
+	private function set_settings( $settings ) {
+		update_option( 'hyve_settings', $settings );
+	}
+
+	/**
+	 * A disabled legacy flag derives the manual mode.
+	 */
+	public function test_derive_manual_from_disabled_chat() {
+		$this->set_settings( [ 'chat_enabled' => false ] );
+
+		$this->assertSame( 'manual', Main::get_settings()['display_mode'] );
+	}
+
+	/**
+	 * An enabled (or unset) legacy flag derives the all-pages mode.
+	 */
+	public function test_derive_all_from_enabled_chat() {
+		$this->set_settings( [ 'chat_enabled' => true ] );
+		$this->assertSame( 'all', Main::get_settings()['display_mode'] );
+
+		$this->set_settings( [] );
+		$this->assertSame( 'all', Main::get_settings()['display_mode'] );
+	}
+
+	/**
+	 * A persisted display_mode always wins over the legacy flag.
+	 */
+	public function test_explicit_display_mode_is_preserved() {
+		$this->set_settings(
+			[
+				'chat_enabled' => false,
+				'display_mode' => 'include',
+			]
+		);
+
+		$this->assertSame( 'include', Main::get_settings()['display_mode'] );
+	}
+
+	/**
+	 * All-pages mode always displays.
+	 */
+	public function test_all_mode_displays() {
+		$this->set_settings( [ 'display_mode' => 'all' ] );
+		$this->go_to( home_url( '/' ) );
+
+		$this->assertTrue( $this->main->should_display_chat() );
+	}
+
+	/**
+	 * Manual mode never auto-displays.
+	 */
+	public function test_manual_mode_does_not_display() {
+		$this->set_settings( [ 'display_mode' => 'manual' ] );
+
+		$this->assertFalse( $this->main->should_display_chat() );
+	}
+
+	/**
+	 * A "contains" rule shows the chat on any URL under that path in include mode.
+	 */
+	public function test_include_path_contains() {
+		$this->set_settings(
+			[
+				'display_mode'  => 'include',
+				'display_rules' => [
+					[
+						'path'     => '/shop',
+						'operator' => 'contains',
+					],
+				],
+			]
+		);
+
+		$_SERVER['REQUEST_URI'] = '/shop/product-a/';
+		$this->assertTrue( $this->main->should_display_chat() );
+
+		$_SERVER['REQUEST_URI'] = '/about/';
+		$this->assertFalse( $this->main->should_display_chat() );
+	}
+
+	/**
+	 * A "matches" rule requires an exact URL in include mode.
+	 */
+	public function test_include_path_matches_exact() {
+		$this->set_settings(
+			[
+				'display_mode'  => 'include',
+				'display_rules' => [
+					[
+						'path'     => '/contact/',
+						'operator' => 'matches',
+					],
+				],
+			]
+		);
+
+		$_SERVER['REQUEST_URI'] = '/contact/';
+		$this->assertTrue( $this->main->should_display_chat() );
+
+		$_SERVER['REQUEST_URI'] = '/contact/sub/';
+		$this->assertFalse( $this->main->should_display_chat() );
+	}
+
+	/**
+	 * Exclude mode is the inverse of include: matching URLs are hidden.
+	 */
+	public function test_exclude_inverts_matching() {
+		$this->set_settings(
+			[
+				'display_mode'  => 'exclude',
+				'display_rules' => [
+					[
+						'path'     => '/shop',
+						'operator' => 'contains',
+					],
+				],
+			]
+		);
+
+		$_SERVER['REQUEST_URI'] = '/shop/product-a/';
+		$this->assertFalse( $this->main->should_display_chat() );
+
+		$_SERVER['REQUEST_URI'] = '/about/';
+		$this->assertTrue( $this->main->should_display_chat() );
+	}
+
+	/**
+	 * The SDK migration persists display_mode from the legacy flag, then stops.
+	 */
+	public function test_migration_persists_display_mode() {
+		update_option( 'hyve_settings', [ 'chat_enabled' => false ] );
+
+		if ( ! class_exists( '\ThemeisleSDK\Modules\Abstract_Migration' ) ) {
+			require_once HYVE_LITE_PATH . '/vendor/codeinwp/themeisle-sdk/src/Modules/Abstract_Migration.php';
+		}
+
+		$migration = require HYVE_LITE_PATH . '/migrations/20260703120000_migrate_chat_display_mode.php';
+
+		$this->assertTrue( $migration->should_run() );
+
+		$migration->up();
+
+		$saved = get_option( 'hyve_settings' );
+		$this->assertSame( 'manual', $saved['display_mode'] );
+		$this->assertFalse( $migration->should_run() );
+	}
+}


### PR DESCRIPTION
## Description

Adds visibility rules for the chat, replacing the single Enable/Disable toggle on the dashboard.

Under **Hyve → Dashboard → "Where should Hyve appear?"** the admin can pick:

- **Show on all pages**
- **Show only on selected content** — the chat appears only on the URLs listed below
- **Show everywhere except selected content** — the chat is hidden on the URLs listed below
- **Don't show automatically** — the chat is only placed via the block or shortcode

For the two "selected content" modes, content is matched by **URL path** with a `contains` (whole section, e.g. `/shop/`) or `matches` (one exact URL) operator. Blocks and shortcodes continue to work for manual placement in every mode.

The old `chat_enabled` toggle is migrated to the new `display_mode` setting automatically (enabled → all pages, disabled → don't show automatically), so existing sites keep their current behavior.

Closes: https://github.com/Codeinwp/hyve/issues/189

## Screenshot

<img width="762" height="555" alt="Screenshot 2026-07-03 at 8 48 26 AM" src="https://github.com/user-attachments/assets/3a947fff-e2ac-458e-8f97-dbd5d73eae86" />


## QA

1. On a site upgrading from a previous version:
   - A site that had chat **enabled** should now show **"Show on all pages"** selected, and the chat still appears everywhere.
   - A site that had chat **disabled** should show **"Don't show automatically"** selected, and the chat does not auto-appear.
2. **Show on all pages** → chat appears on the front page, posts, and pages.
3. **Show only on selected content**:
   - Add a rule `/` with operator **matches** → chat appears only on the homepage.
   - Add a rule `/shop/` with operator **contains** → chat appears on every URL under `/shop/` (e.g. a product), and nowhere else.
   - Click **Save visibility** and confirm "Saved." appears, then reload and confirm the rules persisted.
4. **Show everywhere except selected content**:
   - Add a rule for a page's path → chat appears everywhere **except** that page.
5. **Don't show automatically** → chat does not appear anywhere on its own.
6. In every mode, the **Hyve block** and **`[hyve]` shortcode** still render the chat where placed.
7. The empty-knowledge-base notice and Overview stats on the dashboard still render as before.
