### PR TITLE
feat: register suggested privacy policy content

### DIFF
--- a/inc/Main.php
+++ b/inc/Main.php
@@ -98,6 +98,38 @@ class Main {
 
 		add_filter( 'themeisle_sdk_blackfriday_data', [ $this, 'add_black_friday_data' ] );
 		add_action( 'admin_init', [ $this, 'admin_init' ] );
+		add_action( 'admin_init', [ $this, 'add_privacy_policy_content' ] );
+	}
+
+	/**
+	 * Register suggested privacy policy content.
+	 *
+	 * Surfaces Hyve's third-party data processing (message storage and OpenAI
+	 * processing) in the core Privacy Policy guide at Settings → Privacy.
+	 *
+	 * @since 1.4.2
+	 *
+	 * @return void
+	 */
+	public function add_privacy_policy_content() {
+		if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {
+			return;
+		}
+
+		$content =
+			'<p class="privacy-policy-tutorial">' .
+			__( 'This information is provided to help you disclose how the Hyve chat assistant processes visitor data. Review it and adapt it to your site before publishing.', 'hyve-lite' ) .
+			'</p>' .
+			'<p>' . __( 'When visitors use the Hyve chat assistant on this site, the messages they send are stored on this website so the site administrator can review chat history. No account is required to use the chat.', 'hyve-lite' ) . '</p>' .
+			'<p>' . __( 'To generate replies, the messages are also sent to OpenAI, L.L.C. — a third-party service based in the United States. OpenAI processes the messages to moderate their content, to create numerical representations (embeddings) used to find relevant information, and to generate the assistant\'s responses.', 'hyve-lite' ) . '</p>' .
+			'<p>' . __( 'For details on how OpenAI handles data, see OpenAI\'s privacy policy at https://openai.com/policies/privacy-policy/.', 'hyve-lite' ) . '</p>';
+
+		// Only disclose Qdrant when it is actually connected, so the suggested text reflects the site's real data flows.
+		if ( Qdrant_API::is_active() ) {
+			$content .= '<p>' . __( 'This site also uses Qdrant, a third-party vector database. A numerical representation (embedding) of your message is sent to Qdrant to look up relevant information. See Qdrant\'s privacy policy at https://qdrant.tech/legal/privacy-policy/.', 'hyve-lite' ) . '</p>';
+		}
+
+		wp_add_privacy_policy_content( 'Hyve', wp_kses_post( $content ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Registers suggested privacy-policy text for Hyve via WordPress's `wp_add_privacy_policy_content()`, so site owners get ready-made disclosure of the chat's third-party data processing in the core Privacy Policy guide (**Settings → Privacy → Policy guide**).

The suggested text covers:

- Visitor messages are **stored on the site** so the admin can review chat history (no account required).
- Messages are sent to **OpenAI** (third party, United States) for moderation, embeddings, and completion, with a link to OpenAI's privacy policy.
- When **Qdrant** is connected, an additional line discloses that the message embedding is sent to Qdrant to look up relevant information, with a link to Qdrant's privacy policy. This line is only included when Qdrant is actually active, so the suggestion matches the site's real data flows.

Available in Lite.

Closes: https://github.com/Codeinwp/hyve/issues/187

## Manual QA

1. Go to **Settings → Privacy** and open the **Policy guide** tab (the "Check out our guide" / "Policy guide" button).
2. Confirm a **"Hyve"** section appears with the suggested text describing message storage and OpenAI processing, including the OpenAI privacy-policy link.
3. **Without Qdrant connected**, confirm the Qdrant paragraph is **not** shown.
4. Connect Qdrant (Integrations tab), then reload **Settings → Privacy → Policy guide** and confirm:
   - The **Qdrant paragraph now appears** with the Qdrant privacy-policy link.
   - WordPress shows the "Your Privacy Policy page may need updating" notice reflecting the changed suggestion.
5. Use the **Copy** button on the Hyve section and confirm the intro guidance line (the `.privacy-policy-tutorial` note) is excluded from the copied text, as expected for suggested content.
