### PR TITLE
feat: role-based access to the Messages page

### DIFF
--- a/inc/API.php
+++ b/inc/API.php
@@ -158,25 +158,31 @@ class API extends BaseAPI {
 			],
 			'threads'  => [
 				[
-					'methods'  => \WP_REST_Server::READABLE,
-					'args'     => [
+					'methods'             => \WP_REST_Server::READABLE,
+					'args'                => [
 						'offset' => [
 							'required' => false,
 							'type'     => 'integer',
 							'default'  => 0,
 						],
 					],
-					'callback' => [ $this, 'get_threads' ],
+					'callback'            => [ $this, 'get_threads' ],
+					'permission_callback' => function () {
+						return current_user_can( 'hyve_read_messages' );
+					},
 				],
 				[
-					'methods'  => \WP_REST_Server::DELETABLE,
-					'args'     => [
+					'methods'             => \WP_REST_Server::DELETABLE,
+					'args'                => [
 						'id' => [
 							'required' => true,
 							'type'     => 'integer',
 						],
 					],
-					'callback' => [ $this, 'delete_thread' ],
+					'callback'            => [ $this, 'delete_thread' ],
+					'permission_callback' => function () {
+						return current_user_can( 'hyve_manage_messages' );
+					},
 				],
 			],
 			'qdrant'   => [

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -54,6 +54,7 @@ class Main {
 		new Threads();
 
 		add_action( 'admin_menu', [ $this, 'register_menu_page' ] );
+		add_filter( 'user_has_cap', [ $this, 'grant_message_capabilities' ] );
 		add_action( 'save_post', [ $this, 'update_meta' ], 10, 3 );
 		add_action( 'delete_post', [ $this, 'delete_post' ] );
 		add_filter( 'themeisle_sdk_enable_telemetry', '__return_true' );
@@ -133,6 +134,34 @@ class Main {
 	}
 
 	/**
+	 * Grant the Messages capabilities to administrators.
+	 *
+	 * The two capabilities are custom, so nobody has them by default. Granting
+	 * them to anyone who can `manage_options` keeps the Messages submenu and its
+	 * REST endpoints working for admins. Doing it here, instead of persisting to
+	 * the role, means there is nothing to clean up on uninstall.
+	 *
+	 * To give access to other roles, add the capabilities to them with a
+	 * role-editor plugin or WP_Role::add_cap():
+	 *  - `hyve_read_messages`   view the Messages page and read conversations.
+	 *  - `hyve_manage_messages` delete conversations and export them.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param array<string, bool> $allcaps All capabilities of the current user.
+	 *
+	 * @return array<string, bool>
+	 */
+	public function grant_message_capabilities( $allcaps ) {
+		if ( ! empty( $allcaps['manage_options'] ) ) {
+			$allcaps['hyve_read_messages']   = true;
+			$allcaps['hyve_manage_messages'] = true;
+		}
+
+		return $allcaps;
+	}
+
+	/**
 	 * Register menu page.
 	 *
 	 * @since 1.2.0
@@ -140,7 +169,7 @@ class Main {
 	 * @return void
 	 */
 	public function register_menu_page() {
-		$page_hook_suffix = add_menu_page(
+		add_menu_page(
 			__( 'Hyve', 'hyve-lite' ),
 			__( 'Hyve', 'hyve-lite' ),
 			'manage_options',
@@ -150,7 +179,62 @@ class Main {
 			99
 		);
 
-		add_action( "admin_print_scripts-$page_hook_suffix", [ $this, 'enqueue_options_assets' ] );
+		foreach ( $this->get_submenu_pages() as $slug => $submenu ) {
+			$hook = add_submenu_page(
+				'hyve',
+				$submenu['label'],
+				$submenu['label'],
+				$submenu['capability'],
+				$slug,
+				[ $this, 'menu_page' ]
+			);
+
+			if ( $hook ) {
+				add_action( "admin_print_scripts-$hook", [ $this, 'enqueue_options_assets' ] );
+			}
+		}
+	}
+
+	/**
+	 * Get the Hyve submenu pages.
+	 *
+	 * Each entry mirrors a top-level section of the dashboard app and deep-links
+	 * into it. The `route` is passed to the app so the matching screen opens.
+	 * Messages is gated on `hyve_read_messages` so support staff can reach it
+	 * without seeing the rest of the dashboard.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return array<string, array{label: string, capability: string, route: string}>
+	 */
+	public function get_submenu_pages() {
+		return [
+			'hyve'                => [
+				'label'      => __( 'Dashboard', 'hyve-lite' ),
+				'capability' => 'manage_options',
+				'route'      => 'home',
+			],
+			'hyve-knowledge-base' => [
+				'label'      => __( 'Knowledge Base', 'hyve-lite' ),
+				'capability' => 'manage_options',
+				'route'      => 'data',
+			],
+			'hyve-messages'       => [
+				'label'      => __( 'Messages', 'hyve-lite' ),
+				'capability' => 'hyve_read_messages',
+				'route'      => 'messages',
+			],
+			'hyve-integrations'   => [
+				'label'      => __( 'Integrations', 'hyve-lite' ),
+				'capability' => 'manage_options',
+				'route'      => 'integrations',
+			],
+			'hyve-settings'       => [
+				'label'      => __( 'Settings', 'hyve-lite' ),
+				'capability' => 'manage_options',
+				'route'      => 'settings',
+			],
+		];
 	}
 
 	/**
@@ -184,12 +268,26 @@ class Main {
 			];
 		}
 
+		$submenu_pages = $this->get_submenu_pages();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reading the current admin page to pick the initial app screen, no state change.
+		$current_page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : 'hyve';
+		$current_view = isset( $submenu_pages[ $current_page ] ) ? $submenu_pages[ $current_page ]['route'] : 'home';
+
 		add_filter(
 			'hyve_options_data',
-			function ( $data ) use ( $settings, $post_types_for_js ) {
+			function ( $data ) use ( $settings, $post_types_for_js, $current_view ) {
+				/**
+				 * PHPStan false positive: the return type is an array, but PHPStan cannot infer it because of the dynamic nature of the filter.
+				 * 
+				 * @phpstan-ignore return.type
+				 */
 				return array_merge(
 					$data,
 					[
+						'view'              => $current_view,
+						'canManage'         => current_user_can( 'manage_options' ),
+						'canManageMessages' => current_user_can( 'hyve_manage_messages' ),
 						'api'               => $this->api->get_endpoint(),
 						'rest_url'          => rest_url( $this->api->get_endpoint() ),
 						'postTypes'         => $post_types_for_js,
@@ -221,6 +319,13 @@ class Main {
 	 * @return void
 	 */
 	public function enqueue_options_assets() {
+
+		/**
+		 * Fires before the Hyve dashboard assets are enqueued,
+		 * 
+		 * @since 1.5.0
+		 */
+		do_action( 'hyve_enqueue_options_assets' );
 
 		// @phpstan-ignore include.fileNotFound
 		$asset_file = include HYVE_LITE_PATH . '/build/backend/index.asset.php';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -45,6 +45,15 @@
 
     <rule ref="Generic.Arrays.DisallowLongArraySyntax.Found" />
 
+    <rule ref="WordPress.WP.Capabilities">
+        <properties>
+            <property name="custom_capabilities" type="array">
+                <element value="hyve_read_messages" />
+                <element value="hyve_manage_messages" />
+            </property>
+        </properties>
+    </rule>
+
     <arg name="extensions" value="php" />
     <arg value="s" />
 

--- a/src/backend/App.js
+++ b/src/backend/App.js
@@ -38,7 +38,13 @@ const App = () => {
 			document.dispatchEvent( sdkEvent );
 		};
 
-		fetchData();
+		// Support users without full access cannot read settings; skip the
+		// request so the app finishes loading instead of hanging on a 403.
+		if ( window.hyve?.canManage ) {
+			fetchData();
+		} else {
+			setLoading();
+		}
 
 		const urlParams = new URLSearchParams( window.location.search );
 		const nav = urlParams.get( 'nav' );
@@ -52,7 +58,15 @@ const App = () => {
 		}
 	}, [ setSettings, setLoading, setRoute ] );
 
-	const ROUTE_TREE = applyFilters( 'hyve.route', ROUTE );
+	let ROUTE_TREE = applyFilters( 'hyve.route', ROUTE );
+
+	// Restrict the app to Messages for users who can only read messages, so a
+	// support user never reaches a settings screen or an admin-only request.
+	if ( ! window.hyve?.canManage ) {
+		ROUTE_TREE = ROUTE_TREE.messages
+			? { messages: ROUTE_TREE.messages }
+			: {};
+	}
 
 	const ROUTE_COMPONENTS = Object.keys( ROUTE_TREE ).reduce( ( acc, key ) => {
 		if ( ROUTE_TREE[ key ].component ) {

--- a/src/backend/parts/Messages.js
+++ b/src/backend/parts/Messages.js
@@ -130,13 +130,15 @@ const MessageThreadView = ( { selectedPost, onDelete } ) => {
 				<p className="text-xs text-gray-500">
 					{ selectedPost?.thread_id?.replace( 'thread_', '' ) }
 				</p>
-				<Button
-					isDestructive={ true }
-					aria-label={ __( 'Delete conversation', 'hyve-lite' ) }
-					onClick={ () => onDelete( selectedPost?.ID ) }
-				>
-					<Icon icon={ 'trash' } />
-				</Button>
+				{ window.hyve?.canManageMessages && (
+					<Button
+						isDestructive={ true }
+						aria-label={ __( 'Delete conversation', 'hyve-lite' ) }
+						onClick={ () => onDelete( selectedPost?.ID ) }
+					>
+						<Icon icon={ 'trash' } />
+					</Button>
+				) }
 			</div>
 			<div className="overflow-scroll pl-4 grow">
 				{ selectedPost?.thread?.map( ( message, index ) => (
@@ -333,11 +335,13 @@ const Messages = () => {
 									/>
 								</div>
 							</div>
-							<div className="flex justify-end mt-1">
-								<ExportMessagesAction
-									onClick={ () => setUpsellOpen( true ) }
-								/>
-							</div>
+							{ window.hyve?.canManageMessages && (
+								<div className="flex justify-end mt-1">
+									<ExportMessagesAction
+										onClick={ () => setUpsellOpen( true ) }
+									/>
+								</div>
+							) }
 						</>
 					) }
 				</PanelRow>

--- a/src/backend/parts/Sidebar.js
+++ b/src/backend/parts/Sidebar.js
@@ -28,7 +28,14 @@ const Sidebar = () => {
 
 	const { setRoute } = useDispatch( 'hyve' );
 
-	const MENU_ITEMS = applyFilters( 'hyve.route', ROUTE_TREE );
+	let MENU_ITEMS = applyFilters( 'hyve.route', ROUTE_TREE );
+
+	// Support users who can only read messages see just the Messages entry.
+	if ( ! window.hyve?.canManage ) {
+		MENU_ITEMS = MENU_ITEMS.messages
+			? { messages: MENU_ITEMS.messages }
+			: {};
+	}
 
 	return (
 		<div className="col-span-6 xl:col-span-2">

--- a/src/backend/route.js
+++ b/src/backend/route.js
@@ -68,6 +68,7 @@ export const ROUTE_TREE = {
 		label: __( 'Messages', 'hyve-lite' ),
 		icon: comment,
 		component: Messages,
+		disabled: false,
 	},
 	integrations: {
 		label: __( 'Integrations', 'hyve-lite' ),

--- a/src/backend/store.js
+++ b/src/backend/store.js
@@ -4,7 +4,7 @@
 import { createReduxStore, register } from '@wordpress/data';
 
 const DEFAULT_STATE = {
-	route: 'home',
+	route: window.hyve?.view || 'home',
 	hasLoaded: false,
 	settings: {},
 	processed: [],


### PR DESCRIPTION
## What this adds

Role-based access to the **Messages** page, so a support agent or team member can review chat conversations without being handed the whole Hyve dashboard.

Closes the access side of Codeinwp/hyve#232. Rather than a role picker in settings, this uses two WordPress capabilities (as suggested on the issue), which keeps it native and lets site owners grant access however they already manage roles.

### Capabilities

- `hyve_read_messages` view the Messages page and read conversations.
- `hyve_manage_messages` delete conversations and export them (export lives in Pro).

Administrators get both automatically. To give another role access, add the capability with a role-editor plugin or in code:

```php
// read-only access to Messages for the Editor role
get_role( 'editor' )->add_cap( 'hyve_read_messages' );
// add delete + export
get_role( 'editor' )->add_cap( 'hyve_manage_messages' );
```

The grant for admins is done dynamically via `user_has_cap`, so nothing is written to the roles table and there is nothing to clean up on uninstall.

### Submenus

Every top-level section of the dashboard is now a real WordPress submenu under Hyve (Dashboard, Knowledge Base, Messages, Integrations, Settings), each deep-linking into the app. Messages is gated on `hyve_read_messages`; the rest stay on `manage_options`.

A user who only has `hyve_read_messages` therefore sees just the Hyve to Messages entry, and the app boots into a messages-only view (sidebar restricted to Messages, no settings request, so no 403 hang). The in-app sidebar is unchanged for admins.

### Enforcement

Access is enforced server-side, not just in the UI:

- `GET /threads` requires `hyve_read_messages`
- `DELETE /threads` requires `hyve_manage_messages`

The delete and export buttons are hidden for users without `hyve_manage_messages`, but the REST endpoints are the real gate.

> Pro companion: Codeinwp/hyve#253 gates message export on the same `hyve_manage_messages` capability.

## Manual QA

1. **Admin unchanged.** As an administrator, the Hyve menu now shows submenus (Dashboard, Knowledge Base, Messages, Integrations, Settings). Each opens the matching screen. Everything works as before.
2. **Read-only support user.** Create an Editor user and grant only `hyve_read_messages` (`wp user add-cap <user> hyve_read_messages`). Log in: the Hyve menu shows only Messages, the app opens on Messages, the sidebar is limited to Messages, and there is no delete or export button.
3. **Manage tier.** Add `hyve_manage_messages` to that user. The delete button (and export, on Pro) appears and works.
4. **No access.** A plain Subscriber or an Editor without the capability does not see the Hyve menu at all.
5. **REST is enforced.** With only `hyve_read_messages`, a `DELETE` to `/wp-json/hyve/v1/threads` returns 403.
