### PR TITLE
ci: add translations diff workflow for PRs

### DIFF
--- a/.github/workflows/create-buld-url.yml
+++ b/.github/workflows/create-buld-url.yml
@@ -25,6 +25,12 @@ jobs:
         run: composer install --no-dev --prefer-dist --no-progress --no-suggest
       - name: Install npm deps
         run: npm ci
+      - name: Bump the plugin version
+        run: |
+          CURRENT_VERSION=$(node -p -e "require('./package.json').version")
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          DEV_VERSION="${CURRENT_VERSION}-dev.${COMMIT_HASH}"
+          grunt version::${DEV_VERSION}
       - name: Build files
         run: npm run build
       - name: Create zip

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,0 +1,45 @@
+name: Translations Diff
+
+on:
+  pull_request_review:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
+    branches:
+      - development
+      - main
+
+jobs:
+  translation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Base Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: hyve-lite-base
+      - name: Setup node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+      - name: Checkout PR Branch (Head)
+        uses: actions/checkout@v4
+        with:
+          path: hyve-lite-head
+      - name: Build POT for PR Branch
+        run: |
+          chmod +x ./hyve-lite-head/bin/make-pot.sh
+          ./hyve-lite-head/bin/make-pot.sh ./hyve-lite-head ./hyve-lite-head/languages/hyve-lite.pot
+          ls ./hyve-lite-head/languages/
+      - name: Build POT for Base Branch
+        run: |
+          ./hyve-lite-head/bin/make-pot.sh ./hyve-lite-base ./hyve-lite-base/languages/hyve-lite.pot
+          ls ./hyve-lite-base/languages/
+      - name: Compare POT files
+        uses: Codeinwp/action-i18n-string-reviewer@main
+        with:
+          fail-on-changes: "false"
+          openrouter-key: ${{ secrets.OPEN_ROUTER_API_KEY }}
+          openrouter-model: "google/gemini-2.5-flash"
+          base-pot-file: "hyve-lite-base/languages/hyve-lite.pot"
+          target-pot-file: "hyve-lite-head/languages/hyve-lite.pot"
+          github-token: ${{ secrets.BOT_TOKEN }}

--- a/bin/make-pot.sh
+++ b/bin/make-pot.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Script to generate POT file via Docker
+# Usage: ./bin/make-pot.sh [plugin-path] [destination-path]
+
+# Set defaults
+PLUGIN_PATH="${1:-.}"
+DESTINATION="${2:-.}"
+
+# Resolve absolute paths
+PLUGIN_PATH="$(cd "$PLUGIN_PATH" 2>/dev/null && pwd)" || {
+    echo "Error: Plugin path '$1' does not exist"
+    exit 1
+}
+
+DESTINATION="$(cd "$(dirname "$DESTINATION")" 2>/dev/null && pwd)/$(basename "$DESTINATION")" || {
+    echo "Error: Unable to resolve destination path"
+    exit 1
+}
+
+# Extract destination filename and directory
+DEST_DIR="$(dirname "$DESTINATION")"
+DEST_FILE="$(basename "$DESTINATION")"
+
+# Ensure destination directory exists
+mkdir -p "$DEST_DIR"
+
+echo "Generating POT file..."
+echo "Plugin Path: $PLUGIN_PATH"
+echo "Destination: $DESTINATION"
+echo ""
+
+# Run Docker container with wp-cli to generate POT
+docker run --user root --rm \
+    --volume "$PLUGIN_PATH:/var/www/html/plugin" \
+    wordpress:cli \
+    bash -c 'php -d memory_limit=512M "$(which wp)" --version --allow-root && wp i18n make-pot plugin ./plugin/languages/'"$DEST_FILE"' --include=inc,build,src --allow-root --domain=hyve-lite'
+
+# Check if the file was created inside the container
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✓ POT file successfully generated at: $DESTINATION"
+else
+    echo ""
+    echo "✗ Error generating POT file"
+    exit 1
+fi


### PR DESCRIPTION
Adds the same translations review workflow used in Codeinwp/visualizer.

On PRs targeting development or main, the workflow builds a POT file for both the base and head branches via bin/make-pot.sh (Docker + wp-cli make-pot) and runs Codeinwp/action-i18n-string-reviewer to comment on added, removed, or changed translatable strings.