### PR TITLE
fix: add UTM params to copyright link

### DIFF
--- a/inc/Main.php
+++ b/inc/Main.php
@@ -690,7 +690,7 @@ class Main {
 
 		wp_add_inline_script(
 			'hyve-lite-scripts',
-			'document.addEventListener("DOMContentLoaded", function() { const box = document.querySelector( ".hyve-input-box" ); if ( ! box ) { return; } const c = document.createElement("div"); c.className = "hyve-credits"; c.innerHTML = "<a href=\"https://themeisle.com/plugins/hyve/\" target=\"_blank\">Powered by Hyve</a>"; if ( document.querySelector( ".hyve-privacy-notice" ) ) { c.hidden = true; } box.before( c ); });'
+			'document.addEventListener("DOMContentLoaded", function() { const box = document.querySelector( ".hyve-input-box" ); if ( ! box ) { return; } const c = document.createElement("div"); c.className = "hyve-credits"; c.innerHTML = "<a href=\"https://themeisle.com/plugins/hyve/?utm_source=hyve&utm_medium=chatbot&utm_campaign=copyright\" target=\"_blank\">Powered by Hyve</a>"; if ( document.querySelector( ".hyve-privacy-notice" ) ) { c.hidden = true; } box.before( c ); });'
 		);
 	}
 


### PR DESCRIPTION
Adds UTM tracking parameters (?utm_source=hyve&utm_medium=chatbot&utm_campaign=copyright) to the "Powered by Hyve" copyright link in the chat widget footer.