### PR TITLE
fix: review user-facing text and i18n consistency

### DIFF
--- a/inc/API.php
+++ b/inc/API.php
@@ -1176,7 +1176,7 @@ class API extends BaseAPI {
 				$delete_result = Qdrant_API::instance()->delete_point( $id );
 
 				if ( is_wp_error( $delete_result ) || ! $delete_result ) {
-					throw new \Exception( is_wp_error( $delete_result ) ? $delete_result->get_error_message() : __( 'Failed to delete point in Qdrant.', 'hyve-lite' ) );
+					throw new \Exception( is_wp_error( $delete_result ) ? $delete_result->get_error_message() : __( 'Failed to delete the entry from Qdrant. Please try again or check your Qdrant connection.', 'hyve-lite' ) );
 				}
 			} catch ( \Exception $e ) {
 				return rest_ensure_response( [ 'error' => $e->getMessage() ] );
@@ -1234,7 +1234,7 @@ class API extends BaseAPI {
 		return wp_send_json_success(
 			__( 'Thread removed from local storage.', 'hyve-lite' ) . ' ' . 
 			// translators: this sentence is after 'Thread removed from local storage.'.
-			__( 'It remains accessible via the OpenAI API.', 'hyve-lite' )
+			__( 'The thread remains accessible via the OpenAI API.', 'hyve-lite' )
 		);
 	}
 
@@ -2593,7 +2593,7 @@ class API extends BaseAPI {
 		$message = $request->get_param( 'message' );
 
 		if ( empty( $message ) ) {
-			return new \WP_Error( 'missing_message', __( 'Message was flagged.', 'hyve-lite' ) );
+			return new \WP_Error( 'missing_message', __( 'No message was provided.', 'hyve-lite' ) );
 		}
 
 		$page = Page_Context::instance()->for_request( $request );
@@ -2616,7 +2616,7 @@ class API extends BaseAPI {
 		$moderation = OpenAI::instance()->moderate_chunks( $message );
 
 		if ( true !== $moderation ) {
-			return new \WP_Error( 'content_flagged', __( 'Message was flagged.', 'hyve-lite' ) );
+			return new \WP_Error( 'content_flagged', __( 'This message was flagged by OpenAI moderation and was not answered.', 'hyve-lite' ) );
 		}
 
 		$openai          = OpenAI::instance();
@@ -2631,7 +2631,7 @@ class API extends BaseAPI {
 		$message_vector = $openai->create_embeddings( $retrieval_query );
 
 		if ( is_wp_error( $message_vector ) ) {
-			return new \WP_Error( 'no_embeddings', __( 'No embeddings found.', 'hyve-lite' ) );
+			return new \WP_Error( 'no_embeddings', __( 'Your message could not be processed. Please try again.', 'hyve-lite' ) );
 		}
 
 		$message_vector = reset( $message_vector );

--- a/inc/DB_Table.php
+++ b/inc/DB_Table.php
@@ -694,7 +694,7 @@ class DB_Table {
 
 			return new \WP_Error(
 				'content_failed_moderation',
-				__( 'The content failed moderation policies.', 'hyve-lite' ),
+				__( 'The content failed the moderation check.', 'hyve-lite' ),
 				[ 'review' => $moderation ]
 			);
 		}
@@ -707,7 +707,7 @@ class DB_Table {
 					$delete_result = Qdrant_API::instance()->delete_point( $post_id );
 
 					if ( is_wp_error( $delete_result ) || ! $delete_result ) {
-						throw new \Exception( is_wp_error( $delete_result ) ? $delete_result->get_error_message() : __( 'Failed to delete point in Qdrant.', 'hyve-lite' ) );
+						throw new \Exception( is_wp_error( $delete_result ) ? $delete_result->get_error_message() : __( 'Failed to delete the entry from Qdrant. Please try again or check your Qdrant connection.', 'hyve-lite' ) );
 					}
 				} catch ( \Exception $e ) {
 					return new \WP_Error( 'qdrant_error', $e->getMessage() );
@@ -740,7 +740,7 @@ class DB_Table {
 			);
 
 			if ( ! $post_id ) {
-				return new \WP_Error( 'failed_insert_post', __( 'Failed to insert post.', 'hyve-lite' ) );
+				return new \WP_Error( 'failed_insert_post', __( 'Failed to add post.', 'hyve-lite' ) );
 			}
 		}
 
@@ -2000,9 +2000,10 @@ class DB_Table {
 			$message = $error->get_error_message();
 		}
 
+		// translators: both sentences are appended after the error message that caused the failure.
 		$suffix = $will_retry
-			? __( 'It will be retried automatically.', 'hyve-lite' )
-			: __( 'Please fix the problem and re-add this content.', 'hyve-lite' );
+			? __( 'This content will be retried automatically.', 'hyve-lite' )
+			: __( 'Fix the reported issue and re-add this content.', 'hyve-lite' );
 
 		update_post_meta( $post_id, '_hyve_processing_error', $message . ' ' . $suffix );
 	}

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -1208,7 +1208,7 @@ class Main {
 			'logo'             => 'https://ps.w.org/hyve-lite/assets/icon-256x256.png',
 			'has_upgrade_menu' => 'valid' !== apply_filters( 'product_hyve_license_status', false ),
 			'upgrade_link'     => tsdk_utmify( 'https://themeisle.com/plugins/hyve/', 'about-us' ),
-			'upgrade_text'     => __( 'Get Pro Version', 'hyve-lite' ),
+			'upgrade_text'     => __( 'Upgrade to Pro', 'hyve-lite' ),
 			'review_link'      => 'https://wordpress.org/support/plugin/hyve-lite/reviews/',
 		];
 	}

--- a/inc/OpenAI.php
+++ b/inc/OpenAI.php
@@ -571,7 +571,7 @@ PROMPT;
 		}
 
 		if ( ! isset( $response->id ) || ( isset( $response->status ) && 'queued' !== $response->status ) ) {
-			return new \WP_Error( 'unknown_error', __( 'An error occurred while creating the run.', 'hyve-lite' ) );
+			return new \WP_Error( 'unknown_error', __( 'An error occurred while generating the response. Please try again.', 'hyve-lite' ) );
 		}
 
 		return $response->id;
@@ -827,11 +827,11 @@ PROMPT;
 	 */
 	public function stream_response( $items, $conversation, $on_delta ) {
 		if ( ! $this->api_key ) {
-			return new \WP_Error( 'no_api_key', __( 'API key is missing.', 'hyve-lite' ) );
+			return new \WP_Error( 'no_api_key', __( 'No OpenAI API key is set. Add your API key in the Hyve settings.', 'hyve-lite' ) );
 		}
 
 		if ( ! function_exists( 'curl_init' ) ) {
-			return new \WP_Error( 'no_curl', __( 'cURL is not available.', 'hyve-lite' ) );
+			return new \WP_Error( 'no_curl', __( 'cURL is not available on your server. Ask your hosting provider to enable the PHP cURL extension.', 'hyve-lite' ) );
 		}
 
 		$params           = $this->get_chat_response_params( $items, $conversation );
@@ -840,7 +840,7 @@ PROMPT;
 		$body = wp_json_encode( apply_filters( 'hyve_create_response_params', $params ) );
 
 		if ( false === $body ) {
-			return new \WP_Error( 'invalid_params', __( 'Invalid params.', 'hyve-lite' ) );
+			return new \WP_Error( 'invalid_params', __( 'Invalid request parameters.', 'hyve-lite' ) );
 		}
 
 		$assembled   = '';
@@ -903,7 +903,7 @@ PROMPT;
 				}
 
 				if ( 'response.failed' === $event->type || 'error' === $event->type ) {
-					$stream_err = isset( $event->response->error->message ) ? $event->response->error->message : ( isset( $event->message ) ? $event->message : __( 'Streaming failed.', 'hyve-lite' ) );
+					$stream_err = isset( $event->response->error->message ) ? $event->response->error->message : ( isset( $event->message ) ? $event->message : __( 'The response could not be streamed. Please try again.', 'hyve-lite' ) );
 				}
 			}
 
@@ -952,7 +952,7 @@ PROMPT;
 		}
 
 		if ( false === $ok && '' === $assembled && ! ( function_exists( 'connection_aborted' ) && connection_aborted() ) ) {
-			return new \WP_Error( 'stream_failed', $err ? $err : __( 'Streaming request failed.', 'hyve-lite' ) );
+			return new \WP_Error( 'stream_failed', $err ? $err : __( 'The response could not be streamed. Please try again.', 'hyve-lite' ) );
 		}
 
 		return [
@@ -1150,7 +1150,7 @@ PROMPT;
 		if ( ! $this->api_key ) {
 			return (object) [
 				'error'   => true,
-				'message' => 'API key is missing.',
+				'message' => 'No OpenAI API key is set. Add your API key in the Hyve settings.',
 			];
 		}
 
@@ -1159,7 +1159,7 @@ PROMPT;
 		if ( false === $body ) {
 			return (object) [
 				'error'   => true,
-				'message' => 'Invalid params.',
+				'message' => 'Invalid request parameters.',
 			];
 		}
 

--- a/src/addons/index.js
+++ b/src/addons/index.js
@@ -96,7 +96,11 @@ function initAddPostButton( btnElem ) {
 		} catch ( e ) {
 			if ( parent ) {
 				errorSpanRef = createErrorSpan(
-					e.message || __( 'Unknown error', 'hyve-lite' )
+					e.message ||
+						__(
+							'An unknown error occurred. Please try again.',
+							'hyve-lite'
+						)
 				);
 				parent.appendChild( errorSpanRef );
 			}

--- a/src/backend/components/ModerationModal.js
+++ b/src/backend/components/ModerationModal.js
@@ -63,7 +63,7 @@ const ModerationModal = ( { post, type = '', onClose, onSuccess } ) => {
 		>
 			<p>
 				{ __(
-					'The content of the post listed here could not be added or updated due to non-compliance with content policies. Review these to understand the limitations and possibly modify content to align with required standards.',
+					'The content of the post listed here could not be added or updated due to non-compliance with content policies. Review the flagged categories and edit the content if needed.',
 					'hyve-lite'
 				) }
 			</p>
@@ -106,7 +106,7 @@ const ModerationModal = ( { post, type = '', onClose, onSuccess } ) => {
 
 			<p>
 				{ __(
-					"Occasionally, OpenAI's Moderation system may incorrectly flag content as a violation; these are false positives. Such errors can occur because automated systems sometimes lack the necessary context to interpret nuances accurately. If your content is flagged but you believe it adheres to the guidelines, please manually review it. Should you determine it does not violate the content policies, you can click the button below to override the moderation decision.",
+					"OpenAI's moderation can occasionally flag content by mistake. If you've reviewed your content and believe it complies with the policies, click the button below to override the decision.",
 					'hyve-lite'
 				) }
 			</p>

--- a/src/backend/components/ServiceErrors.js
+++ b/src/backend/components/ServiceErrors.js
@@ -20,13 +20,10 @@ const ServiceErrors = () => {
 		return null;
 	}
 
-	const instructionMessage =
-		__( 'Please test the chat after solving the problem.', 'hyve-lite' ) +
-		' ' +
-		__(
-			'The error will disappear after a successful interaction with the chat.',
-			'hyve-lite'
-		);
+	const instructionMessage = __(
+		'After fixing the issue, send a test message in the chat. The error will clear once a message succeeds.',
+		'hyve-lite'
+	);
 
 	return serviceErrors.map( ( { provider, date, message, code } ) => (
 		<div key={ provider } className="hyve-next-notice is-bad">

--- a/src/backend/screens/ChatAppearance.js
+++ b/src/backend/screens/ChatAppearance.js
@@ -282,7 +282,7 @@ const ChatAppearance = () => {
 									) }
 									target="_blank"
 								>
-									{ __( 'Unlock with Pro', 'hyve-lite' ) }
+									{ __( 'Upgrade to Pro', 'hyve-lite' ) }
 								</Button>
 							</div>
 						) }

--- a/src/backend/screens/ChatBehavior.js
+++ b/src/backend/screens/ChatBehavior.js
@@ -237,7 +237,7 @@ const ConversationCard = () => {
 								) }
 								target="_blank"
 							>
-								{ __( 'Unlock with Pro', 'hyve-lite' ) }
+								{ __( 'Upgrade to Pro', 'hyve-lite' ) }
 							</Button>
 						</div>
 					) }
@@ -290,7 +290,7 @@ const ConversationCard = () => {
 					</>
 				}
 				description={ __(
-					'Shape the assistant’s tone and persona with your own instructions. The built-in answer format and Knowledge Base rules always stay in effect.',
+					"Shape the assistant's tone and persona with your own instructions. The built-in answer format and Knowledge Base rules always stay in effect.",
 					'hyve-lite'
 				) }
 			>
@@ -466,7 +466,7 @@ const SuggestionsCard = () => {
 						) }
 						target="_blank"
 					>
-						{ __( 'Unlock with Pro', 'hyve-lite' ) }
+						{ __( 'Upgrade to Pro', 'hyve-lite' ) }
 					</Button>
 				</div>
 			) }
@@ -659,7 +659,7 @@ const ProactiveCard = () => {
 						) }
 						target="_blank"
 					>
-						{ __( 'Unlock with Pro', 'hyve-lite' ) }
+						{ __( 'Upgrade to Pro', 'hyve-lite' ) }
 					</Button>
 				</div>
 			) }
@@ -740,7 +740,7 @@ const TrustCard = () => {
 							<p className="hyve-next-notice__text">
 								{ createInterpolateElement(
 									__(
-										'No Privacy Policy page is set, so the notice won’t appear on your site yet. Choose one under <a>Settings → Privacy</a>.',
+										"No Privacy Policy page is set, so the notice won't appear on your site yet. Choose one under <a>Settings → Privacy</a>.",
 										'hyve-lite'
 									),
 									{ a: privacyLink }

--- a/src/backend/screens/Connect.js
+++ b/src/backend/screens/Connect.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 
 import apiFetch from '@wordpress/api-fetch';
 
@@ -346,7 +346,7 @@ export const ConnectPanel = () => {
 									) }
 								</strong>{ ' ' }
 								{ __(
-									'You are on free plan limits until you renew it. Your assistant keeps answering in the meantime.',
+									'You are on free plan limits until you renew your license. Your assistant keeps answering in the meantime.',
 									'hyve-lite'
 								) }
 							</div>
@@ -424,7 +424,11 @@ export const ConnectPanel = () => {
 									label={ __( 'Chat messages', 'hyve-lite' ) }
 									used={ chatQuota.used }
 									limit={ chatQuota.limit }
-									unit={ __( 'this month', 'hyve-lite' ) }
+									unit={ _x(
+										'this month',
+										'chat quota period',
+										'hyve-lite'
+									) }
 									sub={
 										chatQuota.full
 											? __(
@@ -609,7 +613,7 @@ export const ConnectPanel = () => {
 								) }
 							</strong>{ ' ' }
 							{ __(
-								"Hyve Connect and a self-hosted key can't run at the same time. Enabling it stops using your key, and your indexed content will be synced to Hyve Connect.",
+								"Hyve Connect and a self-hosted key can't run at the same time. Enabling it stops Hyve from using your key, and your indexed content will be synced to Hyve Connect.",
 								'hyve-lite'
 							) }
 						</div>

--- a/src/backend/screens/Dashboard.js
+++ b/src/backend/screens/Dashboard.js
@@ -505,7 +505,7 @@ const RecentConversations = () => {
 						href={ setUtm( window.hyve?.pro, 'messages-feature' ) }
 						target="_blank"
 					>
-						{ __( 'Unlock with Pro', 'hyve-lite' ) }
+						{ __( 'Upgrade to Pro', 'hyve-lite' ) }
 					</Button>
 				</div>
 			) }

--- a/src/backend/screens/Integrations.js
+++ b/src/backend/screens/Integrations.js
@@ -212,7 +212,7 @@ export const QdrantPanel = () => {
 						<div className="hyve-next-card__intro">
 							<p>
 								{ __(
-									"Use Qdrant to increase the Knowledge Base limit of Hyve. By integrating Qdrant, you can manage larger datasets and improve query performance for your website. To integrate Qdrant with your application, you'll need an API key and endpoint.",
+									"Connect Qdrant to lift Hyve's Knowledge Base limit, handle larger datasets, and speed up search queries. You'll need your Qdrant API key and endpoint.",
 									'hyve-lite'
 								) }
 							</p>
@@ -456,7 +456,7 @@ export const ApiAccessPanel = () => {
 				<div className="hyve-next-card__body">
 					<p>
 						{ __(
-							'Enable external services to search your Knowledge Base using advanced semantic search powered by Retrieval-Augmented Generation (RAG) and OpenAI embeddings.',
+							'Let external services search your Knowledge Base with semantic search powered by Retrieval-Augmented Generation (RAG) and OpenAI embeddings.',
 							'hyve-lite'
 						) }{ ' ' }
 						{ __(
@@ -492,7 +492,7 @@ export const ApiAccessPanel = () => {
 						</strong>
 						<p>
 							{ __(
-								'Upgrade to Pro to unlock advanced access management: generate and manage secure API tokens, and control who can access your Knowledge Base via external integrations. Empower your team and automate workflows with confidence and security.',
+								'Upgrade to Pro to unlock advanced access management: generate and manage secure API tokens, and control who can access your Knowledge Base via external integrations.',
 								'hyve-lite'
 							) }
 						</p>
@@ -501,7 +501,7 @@ export const ApiAccessPanel = () => {
 							href={ setUtm( window.hyve?.pro, 'api-search' ) }
 							target="_blank"
 						>
-							{ __( 'Unlock with Pro', 'hyve-lite' ) }
+							{ __( 'Upgrade to Pro', 'hyve-lite' ) }
 						</Button>
 					</div>
 				) }

--- a/src/backend/screens/KnowledgeBase.js
+++ b/src/backend/screens/KnowledgeBase.js
@@ -914,7 +914,7 @@ const WordPressDrill = () => {
 				<div className="hyve-next-card__intro">
 					<p>
 						{ __(
-							'Select posts that are informative, engaging, and relevant. These will be the building blocks that empower your chat assistant to deliver precise and helpful responses. Whether it is answering FAQs or diving into detailed explanations, the content you choose here will shape how effectively your assistant interacts with users.',
+							'Select posts that are informative and relevant. Your assistant answers only from this content, so what you add here determines how well it can help visitors.',
 							'hyve-lite'
 						) }
 					</p>
@@ -1562,12 +1562,12 @@ const AttentionPanel = () => {
 const LOCKED_COPY = {
 	'source-custom': {
 		body: __(
-			'Custom Data allows you to privately feed specific data directly into your chatbot without displaying this information on your public website. With this, you can equip your bot with unique, specialized knowledge that aligns with your business needs and customer queries.',
+			'Custom Data lets you feed information to your chatbot privately, without publishing it on your site.',
 			'hyve-lite'
 		),
 		title: __( 'Custom Data is a Premium feature', 'hyve-lite' ),
 		text: __(
-			'Privately feed specific data directly into your chatbot, equipping it with specialized knowledge that aligns with your business needs and customer queries. Upgrade now!',
+			'Privately feed specific data directly into your chatbot, equipping it with specialized knowledge that aligns with your business needs and customer queries.',
 			'hyve-lite'
 		),
 		campaign: 'custom-data-feature',
@@ -1579,7 +1579,7 @@ const LOCKED_COPY = {
 		),
 		title: __( 'URL Crawling is a Premium feature', 'hyve-lite' ),
 		text: __(
-			'Crawl any web page and add its content to the Knowledge Base. Upgrade now!',
+			'Crawl any web page and add its content to the Knowledge Base.',
 			'hyve-lite'
 		),
 		campaign: 'website-crawling-feature',
@@ -1591,7 +1591,7 @@ const LOCKED_COPY = {
 		),
 		title: __( 'Sitemap Crawling is a Premium feature', 'hyve-lite' ),
 		text: __(
-			'Use this tool to crawl a website and add its content to the Knowledge Base using the sitemap. Upgrade now!',
+			'Use this tool to crawl a website and add its content to the Knowledge Base using the sitemap.',
 			'hyve-lite'
 		),
 		campaign: 'sitemap-crawling-feature',
@@ -1603,7 +1603,7 @@ const LOCKED_COPY = {
 		),
 		title: __( 'Document Import is a Premium feature', 'hyve-lite' ),
 		text: __(
-			'Upload PDF, Word, Markdown, Text, and CSV files and add their content to the Knowledge Base. Upgrade now!',
+			'Upload PDF, Word, Markdown, Text, and CSV files and add their content to the Knowledge Base.',
 			'hyve-lite'
 		),
 		campaign: 'document-import-feature',
@@ -1640,7 +1640,10 @@ const LOCKED_PREVIEWS = {
 		],
 		rows: [
 			__( 'Halloween Limited Time Deal Information', 'hyve-lite' ),
-			__( 'What to do if my order is missing an item?', 'hyve-lite' ),
+			__(
+				'What should I do if my order is missing an item?',
+				'hyve-lite'
+			),
 			__( 'How do I return an item?', 'hyve-lite' ),
 			__( 'How do I track my order?', 'hyve-lite' ),
 			__( 'How do I change my delivery address?', 'hyve-lite' ),
@@ -1749,7 +1752,7 @@ const LockedSource = ( { subKey } ) => {
 							href={ setUtm( window.hyve?.pro, copy.campaign ) }
 							target="_blank"
 						>
-							{ __( 'Unlock with Pro', 'hyve-lite' ) }
+							{ __( 'Upgrade to Pro', 'hyve-lite' ) }
 						</Button>
 					</div>
 				) }
@@ -1804,7 +1807,7 @@ const FaqPanel = () => {
 			<div className="hyve-next-card__body">
 				<p>
 					{ __(
-						"The FAQ captures frequently asked questions that went unanswered by our chatbot, providing you with a valuable insight into what your users are seeking. This feature allows you to review these queries and decide whether to incorporate them into your bot's knowledge base. By actively updating your FAQ, you can continuously refine your chatbot's ability to address user needs effectively and enhance their interactive experience. These aren't updated instantly.",
+						"FAQ lists the questions your chatbot couldn't answer, along with how often each was asked, so you can see what visitors need most. Review them and add answers to your Knowledge Base. This list updates periodically, not in real time.",
 						'hyve-lite'
 					) }
 				</p>
@@ -1870,7 +1873,7 @@ const FaqPanel = () => {
 						</strong>
 						<p>
 							{ __(
-								"Review unanswered questions, enhance your bot's knowledge base, and refine your users' interactive experience. Upgrade now!",
+								"Review unanswered questions, enhance your bot's knowledge base, and refine your users' interactive experience.",
 								'hyve-lite'
 							) }
 						</p>
@@ -1879,7 +1882,7 @@ const FaqPanel = () => {
 							href={ setUtm( window.hyve?.pro, 'faq-feature' ) }
 							target="_blank"
 						>
-							{ __( 'Unlock with Pro', 'hyve-lite' ) }
+							{ __( 'Upgrade to Pro', 'hyve-lite' ) }
 						</Button>
 					</div>
 				</>

--- a/src/backend/screens/Leads.js
+++ b/src/backend/screens/Leads.js
@@ -72,7 +72,7 @@ const LeadsPreview = () => (
 			<FieldRow
 				label={ __( 'Before the chat starts', 'hyve-lite' ) }
 				description={ __(
-					'Ask visitors to fill the form before their first message.',
+					'Ask visitors to fill in the form before their first message.',
 					'hyve-lite'
 				) }
 			>

--- a/src/backend/screens/Messages.js
+++ b/src/backend/screens/Messages.js
@@ -315,7 +315,7 @@ const ConversationsPanel = () => {
 						href={ setUtm( window.hyve?.pro, 'messages-feature' ) }
 						target="_blank"
 					>
-						{ __( 'Unlock with Pro', 'hyve-lite' ) }
+						{ __( 'Upgrade to Pro', 'hyve-lite' ) }
 					</Button>
 				</div>
 			) }
@@ -327,16 +327,19 @@ const DEMO_LEADS = [
 	{
 		name: 'Jane Cooper',
 		email: 'jane@example.com',
+		/* translators: sample date shown in the Pro upsell preview. */
 		date: __( 'Apr 12', 'hyve-lite' ),
 	},
 	{
 		name: 'Devon Lane',
 		email: 'devon@example.com',
+		/* translators: sample date shown in the Pro upsell preview. */
 		date: __( 'Apr 9', 'hyve-lite' ),
 	},
 	{
 		name: 'Courtney Henry',
 		email: 'courtney@example.com',
+		/* translators: sample date shown in the Pro upsell preview. */
 		date: __( 'Apr 2', 'hyve-lite' ),
 	},
 ];

--- a/src/backend/screens/Skills.js
+++ b/src/backend/screens/Skills.js
@@ -22,7 +22,7 @@ const PREVIEW = [
 	{
 		label: __( 'Check order status', 'hyve-lite' ),
 		description: __(
-			'Look up the status of an order by its number or the customer’s email.',
+			"Look up the status of an order by its number or the customer's email.",
 			'hyve-lite'
 		),
 	},
@@ -72,7 +72,7 @@ const Skills = () => {
 			<div className="hyve-next-card__intro">
 				<p>
 					{ __(
-						'Let the assistant do things live, like checking an order or looking up stock, by calling functions your plugins provide. It only calls the ones you allow, and each call still respects that function’s own permissions.',
+						"Let the assistant do things live, like checking an order or looking up stock, by calling functions your plugins provide. It only calls the ones you allow, and each call still respects that function's own permissions.",
 						'hyve-lite'
 					) }
 				</p>

--- a/src/block/index.js
+++ b/src/block/index.js
@@ -46,7 +46,7 @@ registerBlockType( metadata.name, {
 									'hyve-lite'
 								) }{ ' ' }
 								{ __(
-									'The Chat won’t be able to respond to questions until sources are added.',
+									"The Chat won't be able to respond to questions until sources are added.",
 									'hyve-lite'
 								) }
 								<Button
@@ -61,10 +61,7 @@ registerBlockType( metadata.name, {
 										);
 									} }
 								>
-									{ __(
-										'Click here to add content.',
-										'hyve-lite'
-									) }
+									{ __( 'Add content', 'hyve-lite' ) }
 								</Button>
 							</p>
 						</Notice>

--- a/tests/e2e/specs/block.spec.js
+++ b/tests/e2e/specs/block.spec.js
@@ -22,7 +22,7 @@ test.describe( 'Block Editor', () => {
 			page
 				.locator( 'iframe[name="editor-canvas"]' )
 				.contentFrame()
-				.getByRole( 'button', { name: 'Click here to add content.' } )
+				.getByRole( 'button', { name: 'Add content' } )
 		).toBeVisible();
 
 		await expect(

--- a/tests/e2e/specs/knowledge-base.spec.js
+++ b/tests/e2e/specs/knowledge-base.spec.js
@@ -189,7 +189,7 @@ test.describe( 'Knowledge Base', () => {
 			page.getByText( 'Halloween Limited Time Deal Information' )
 		).toBeVisible();
 		await expect(
-			page.getByRole( 'link', { name: 'Unlock with Pro' } )
+			page.getByRole( 'link', { name: 'Upgrade to Pro' } )
 		).toBeVisible();
 
 		// The back link returns to the sources grid.
@@ -218,7 +218,7 @@ test.describe( 'Knowledge Base', () => {
 			page.getByText( 'How do I reset my password?' )
 		).toBeVisible();
 		await expect(
-			page.getByRole( 'link', { name: 'Unlock with Pro' } )
+			page.getByRole( 'link', { name: 'Upgrade to Pro' } )
 		).toBeVisible();
 	} );
 

--- a/tests/e2e/specs/knowledge-base.spec.js
+++ b/tests/e2e/specs/knowledge-base.spec.js
@@ -189,7 +189,9 @@ test.describe( 'Knowledge Base', () => {
 			page.getByText( 'Halloween Limited Time Deal Information' )
 		).toBeVisible();
 		await expect(
-			page.getByRole( 'link', { name: 'Upgrade to Pro' } )
+			page
+				.locator( '.hyve-next-act__upsell' )
+				.getByRole( 'link', { name: 'Upgrade to Pro' } )
 		).toBeVisible();
 
 		// The back link returns to the sources grid.
@@ -218,7 +220,9 @@ test.describe( 'Knowledge Base', () => {
 			page.getByText( 'How do I reset my password?' )
 		).toBeVisible();
 		await expect(
-			page.getByRole( 'link', { name: 'Upgrade to Pro' } )
+			page
+				.locator( '.hyve-next-act__upsell' )
+				.getByRole( 'link', { name: 'Upgrade to Pro' } )
 		).toBeVisible();
 	} );
 

--- a/tests/e2e/specs/messages.spec.js
+++ b/tests/e2e/specs/messages.spec.js
@@ -187,7 +187,9 @@ test.describe( 'Messages', () => {
 			page.getByText( 'Read every conversation' )
 		).toBeVisible();
 		await expect(
-			page.getByRole( 'link', { name: 'Upgrade to Pro' } )
+			page
+				.locator( '.hyve-next-act__upsell' )
+				.getByRole( 'link', { name: 'Upgrade to Pro' } )
 		).toBeVisible();
 	} );
 } );

--- a/tests/e2e/specs/messages.spec.js
+++ b/tests/e2e/specs/messages.spec.js
@@ -187,7 +187,7 @@ test.describe( 'Messages', () => {
 			page.getByText( 'Read every conversation' )
 		).toBeVisible();
 		await expect(
-			page.getByRole( 'link', { name: 'Unlock with Pro' } )
+			page.getByRole( 'link', { name: 'Upgrade to Pro' } )
 		).toBeVisible();
 	} );
 } );

--- a/tests/e2e/specs/settings.spec.js
+++ b/tests/e2e/specs/settings.spec.js
@@ -132,7 +132,7 @@ test.describe( 'Settings', () => {
 			card.getByText( 'Start conversations before visitors do' )
 		).toBeVisible();
 		await expect(
-			card.getByRole( 'link', { name: 'Unlock with Pro' } )
+			card.getByRole( 'link', { name: 'Upgrade to Pro' } )
 		).toBeVisible();
 
 		// The trigger select is locked on Disabled, so the invite message
@@ -293,7 +293,7 @@ test.describe( 'Settings', () => {
 			page.getByText( 'Search your Knowledge Base from anywhere' )
 		).toBeVisible();
 		await expect(
-			page.getByRole( 'link', { name: 'Unlock with Pro' } )
+			page.getByRole( 'link', { name: 'Upgrade to Pro' } )
 		).toBeVisible();
 	} );
 } );

--- a/tests/e2e/specs/settings.spec.js
+++ b/tests/e2e/specs/settings.spec.js
@@ -293,7 +293,9 @@ test.describe( 'Settings', () => {
 			page.getByText( 'Search your Knowledge Base from anywhere' )
 		).toBeVisible();
 		await expect(
-			page.getByRole( 'link', { name: 'Upgrade to Pro' } )
+			page
+				.locator( '.hyve-next-act__upsell' )
+				.getByRole( 'link', { name: 'Upgrade to Pro' } )
 		).toBeVisible();
 	} );
 } );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -204,7 +204,7 @@ export async function mockConfirmDeleteThreadResponse( page ) {
 				contentType: 'application/json',
 				body: JSON.stringify( {
 					success: true,
-					data: 'Thread removed from local storage. It remains accessible via the OpenAI API.',
+					data: 'Thread removed from local storage. The thread remains accessible via the OpenAI API.',
 				} ),
 			} );
 		} else {


### PR DESCRIPTION
### Changes:

| Where | Before → After | Why |
|---|---|---|
| ChatAppearance.js, ChatBehavior.js, Dashboard.js, Integrations.js, KnowledgeBase.js, Messages.js — 9 spots | `Unlock with Pro` → `Upgrade to Pro` | Same CTA had two different labels across the admin |
| Main.php | `Get Pro Version` → `Upgrade to Pro` | Third variant of the same CTA |
| API.php | `Message was flagged.` → `No message was provided.` | **Bug** — the empty-message branch reused the moderation string, so a blank message reported as flagged content |
| API.php | `Message was flagged.` → `This message was flagged by OpenAI moderation and was not answered.` | Didn't say who flagged it or what happened as a result |
| API.php | `No embeddings found.` → `Your message could not be processed. Please try again.` | Shown to chat visitors, who don't know what an embedding is |
| API.php | `It remains accessible via the OpenAI API.` → `The thread remains accessible via the OpenAI API.` | Fragment appended to another string; "It" had no antecedent once translated on its own |
| API.php, DB_Table.php | `Failed to delete point in Qdrant.` → `Failed to delete the entry from Qdrant. Please try again or check your Qdrant connection.` | "Point" is Qdrant-internal, and no recovery step was offered |
| OpenAI.php | `API key is missing.` → `No OpenAI API key is set. Add your API key in the Hyve settings.` | Didn't say which key or where to add it |
| OpenAI.php | `cURL is not available.` → `cURL is not available on your server. Ask your hosting provider to enable the PHP cURL extension.` | Server-level issue the user can't fix from WP admin |
| OpenAI.php | `An error occurred while creating the run.` → `An error occurred while generating the response. Please try again.` | "Run" is OpenAI API jargon |
| OpenAI.php, OpenAI.php | `Streaming failed.` / `Streaming request failed.` → `The response could not be streamed. Please try again.` | Two strings for one condition |
| OpenAI.php | `Invalid params.` → `Invalid request parameters.` | Abbreviation |
| DB_Table.php | `The content failed moderation policies.` → `The content failed the moderation check.` | Grammar |
| DB_Table.php | `Failed to insert post.` → `Failed to add post.` | "Insert" is database jargon |
| DB_Table.php | `It will be retried automatically.` / `Please fix the problem and re-add this content.` → `This content will be retried automatically.` / `Fix the reported issue and re-add this content.` | Fragments appended after an error message; added a translator comment explaining that |
| index.js | `Unknown error` → `An unknown error occurred. Please try again.` | Fragment, not a sentence |
| ServiceErrors.js | `__( 'Please test the chat…' ) + ' ' + __( 'The error will disappear…' )` → single `__( 'After fixing the issue, send a test message in the chat. The error will clear once a message succeeds.' )` | One sentence built by concatenating two strings at runtime — word order is language-specific, so it can't translate correctly |
| index.js | `Click here to add content.` → `Add content` | "Click here" is an accessibility anti-pattern for button text |
| ModerationModal.js | `…Review these to understand the limitations and possibly modify content to align with required standards.` → `…Review the flagged categories and edit the content if needed.` | Names what's actually on screen instead of describing it abstractly |
| ModerationModal.js | 4-sentence false-positive explanation → `OpenAI's moderation can occasionally flag content by mistake. If you've reviewed your content and believe it complies with the policies, click the button below to override the decision.` | Override mechanism kept; two sentences hedging about automated systems removed |
| Integrations.js | `Use Qdrant to increase the Knowledge Base limit of Hyve. By integrating Qdrant…` → `Connect Qdrant to lift Hyve's Knowledge Base limit, handle larger datasets, and speed up search queries. You'll need your Qdrant API key and endpoint.` | Said "integrate Qdrant" three times; all three benefits kept |
| Integrations.js | `Enable external services to search… using advanced semantic search powered by RAG and OpenAI embeddings.` → `Let external services search your Knowledge Base with semantic search powered by Retrieval-Augmented Generation (RAG) and OpenAI embeddings.` | Only the verbose framing removed — technical terms kept for a developer audience |
| Integrations.js | `…Empower your team and automate workflows with confidence and security.` → *(removed)* | No information |
| KnowledgeBase.js | `Select posts that are informative, engaging, and relevant. These will be the building blocks…` → `Select posts that are informative and relevant. Your assistant answers only from this content, so what you add here determines how well it can help visitors.` | States the actual constraint, which the original never did |
| KnowledgeBase.js | 4-sentence FAQ paragraph → `FAQ lists the questions your chatbot couldn't answer, along with how often each was asked, so you can see what visitors need most. Review them and add answers to your Knowledge Base. This list updates periodically, not in real time.` | Keeps the frequency count and the review choice that the panel actually shows; drops one sentence that restated the previous one |
| KnowledgeBase.js | `Custom Data allows you to privately feed specific data… With this, you can equip your bot…` → `Custom Data lets you feed information to your chatbot privately, without publishing it on your site.` | Second sentence duplicated the upsell text directly below it |
| KnowledgeBase.js — 5 spots | `… Upgrade now!` → *(removed)* | Sits directly above an "Upgrade to Pro" button |
| KnowledgeBase.js | `What to do if my order is missing an item?` → `What should I do if my order is missing an item?` | Grammar |
| Connect.js | `until you renew it` → `until you renew your license` | "It" read as the plan rather than the license |
| Connect.js | `Enabling it stops using your key` → `Enabling it stops Hyve from using your key` | Missing subject read as if the user stops |
| Connect.js | `__( 'this month' )` → `_x( 'this month', 'chat quota period' )` | Two-word fragment with no context in the translation queue |
| Leads.js | `Ask visitors to fill the form` → `Ask visitors to fill in the form` | Grammar |
| ChatBehavior.js, Skills.js, index.js — 5 spots | `’` → `'` | Rest of the codebase uses straight apostrophes |
| Messages.js | `Apr 12` / `Apr 9` / `Apr 2` — text unchanged, translator comments added | Bare dates are meaningless in a translation queue |
| block.spec.js, knowledge-base.spec.js, messages.spec.js, settings.spec.js, utils.js | Selector text and one mock response updated to match | `getByRole` matches on visible text, so these would fail otherwise |