### PR TITLE
feat: redirect to dashboard on activation and to Knowledge Base after first Connect

### DIFF
--- a/hyve-lite.php
+++ b/hyve-lite.php
@@ -67,6 +67,32 @@ add_filter(
 	}
 );
 
+register_activation_hook(
+	__FILE__,
+	function () {
+		set_transient( 'hyve_lite_activation_redirect', 1, 30 );
+	}
+);
+
+add_action(
+	'admin_init',
+	function () {
+		if ( ! get_transient( 'hyve_lite_activation_redirect' ) ) {
+			return;
+		}
+
+		delete_transient( 'hyve_lite_activation_redirect' );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only detecting a bulk activation to skip the redirect; no state change.
+		if ( isset( $_GET['activate-multi'] ) || is_network_admin() || ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		wp_safe_redirect( admin_url( 'admin.php?page=hyve' ) );
+		exit;
+	}
+);
+
 add_action(
 	'plugins_loaded',
 	function () {

--- a/src/backend/screens/Connect.js
+++ b/src/backend/screens/Connect.js
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
  * Internal dependencies.
  */
 import { setUtm, percentOf, quotaOf } from '../utils';
+import { navigate } from '../router';
 import Card from '../components/Card';
 import Chip from '../components/Chip';
 import FieldRow from '../components/FieldRow';
@@ -95,6 +96,9 @@ export const ConnectPanel = () => {
 	const isQdrantActive = useSelect( ( select ) =>
 		select( 'hyve' ).isQdrantActive()
 	);
+	const totalChunks = useSelect( ( select ) =>
+		select( 'hyve' ).getTotalChunks()
+	);
 
 	const { setSetting, setAiMode, setConnect, setConnectSync } =
 		useDispatch( 'hyve' );
@@ -159,6 +163,12 @@ export const ConnectPanel = () => {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
+
+			// Empty Knowledge Base: continue to the next checklist step once
+			// the connected state has had a moment to show.
+			if ( 0 === Number( totalChunks ?? 0 ) ) {
+				setTimeout( () => navigate( 'kb' ), 2000 );
+			}
 		} catch ( error ) {
 			createNotice( 'error', error?.message ?? String( error ), {
 				type: 'snackbar',


### PR DESCRIPTION
After activating Hyve Lite, users are left on the WordPress plugins list with no pointer to what to do next, and after enabling Hyve Connect they stay on the settings screen even though their Knowledge Base is still empty. This PR moves users along the setup checklist automatically at both of those moments.

## What changed

- **Activation** — activating the plugin now redirects to the Hyve dashboard (`admin.php?page=hyve`), where the setup checklist is shown. Before → after: plugins list with a "Plugin activated" notice → dashboard with the "Let's get Hyve running" checklist. The redirect is skipped for bulk plugin activations, network admin, and users without `manage_options`.

- **Connect** — after "Enable Hyve Connect" succeeds and the Knowledge Base is still empty, the app waits 2 seconds (so the "Connected" chip and snackbar are visible) and then navigates to the Knowledge Base screen, the next checklist step. Users who already have indexed content (e.g. switching from their own OpenAI key) stay on the settings screen.

## Onboarding flow

```mermaid
flowchart LR
    A[Activate plugin] --> B{New:<br/>single activation<br/>by an admin?}:::added
    B -- Yes --> C[New:<br/>Redirect to Hyve<br/>dashboard checklist]:::added
    B -- No --> D[Stay on plugins list]
    C --> E[Enable Hyve Connect]
    E --> F{New:<br/>Knowledge Base<br/>empty?}:::added
    F -- Yes --> G[New:<br/>Redirect to Knowledge<br/>Base after 2s]:::added
    F -- No --> H[Stay on settings]

    classDef added fill:#1a7f37,color:#fff,stroke:#116329,stroke-width:3px
```

## Data changes

| Key | Value | Lifetime |
| --- | --- | --- |
| `hyve_lite_activation_redirect` (transient) | `1` | 30 seconds, deleted on first `admin_init` |

## QA

1. On a site where Hyve Lite was never installed (or after deleting all `hyve` options), go to WP Admin → Plugins → Installed Plugins and activate **Hyve Lite**.
   **Expect:** you land on the Hyve dashboard (`/wp-admin/admin.php?page=hyve`) showing the setup checklist, not on the plugins list.

2. From the checklist, click **Connect to AI**, then on Settings → Hyve Connect click **Enable Hyve Connect**.
   **Expect:** the "Connected" chip and "Hyve Connect is on." snackbar appear, and about 2 seconds later the app navigates to the Knowledge Base screen on its own.

3. Go back to WP Admin → Plugins, deactivate Hyve Lite, select it together with another plugin, and use Bulk actions → Activate.
   **Expect:** you stay on the plugins list; no redirect.

4. Disconnect Hyve Connect (Settings → Hyve Connect → Disconnect), add at least one post to the Knowledge Base using your own OpenAI key, then enable Hyve Connect again.
   **Expect:** after the sync you remain on the settings screen; no redirect to the Knowledge Base.
