### PR TITLE
fix: enlarge default chat window to 450x720 and fix menu labels in LTR and RTL

### DIFF
--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -145,8 +145,8 @@ body.wp-admin {
 	display: none;
 	flex-direction: column;
 	box-sizing: border-box;
-	width: 384px;
-	height: min(620px, calc(100vh - 110px));
+	width: 450px;
+	height: min(720px, calc(100vh - 110px));
 	border-radius: $hyve-radius;
 	background-color: var( --chat_background, #ffffff );
 	overflow: hidden;
@@ -302,7 +302,7 @@ body.wp-admin {
 					background: none;
 					text-align: left;
 					cursor: pointer;
-					font-size: 14px;
+					font-size: 12px;
 					font-family: inherit;
 					border-radius: 8px;
 					display: flex;
@@ -323,6 +323,13 @@ body.wp-admin {
 				}
 			}
 		}
+	}
+
+	// In RTL the header menu button sits on the inline-start side, so the
+	// dropdown must open toward the window interior instead of off-screen.
+	[dir="rtl"] & .hyve-header .hyve-menu-container .hyve-menu-dropdown {
+		right: auto;
+		left: 0;
 	}
 
 	// ---- Footer / input ----


### PR DESCRIPTION
## Context
Fixes #233

Fixes on the **frontend** chat widget only (no wp-admin changes):
- Default window 384×620 → **450×720**.
- Header menu (⋯): "Clear Conversation" wrapped to a second line in LTR, and in **RTL** the dropdown hung out of the panel's left edge and was clipped by `overflow: hidden`.

## Changes
`src/frontend/style.scss`
- `.hyve-window`: `width: 384px → 450px`, height `min(620px, …) → min(720px, calc(100vh - 110px))` (viewport cap preserved).
- `.hyve-menu-item`: `font-size: 14px → 12px` so the label fits on one line in the 190px dropdown.
- RTL: add `[dir="rtl"] … .hyve-menu-dropdown { right: auto; left: 0; }` so the menu opens toward the window interior instead of off the panel edge.

## Verification
- SCSS compiles clean (sass); branch based on `development` (diff is only this file).
- Live LTR probe (mscamohali.com): window 450×720, "Clear Conversation" one line, dropdown inside panel.
- Faithful RTL page probe: header direction rtl, button on inline-start, dropdown fully inside the panel (no clip), label one line.
- Visual confirmation via vision model (OpenRouter Luna) on before/after screenshots: BEFORE menu clipped off left edge in RTL; AFTER fully inside, both labels on one line, in LTR and RTL.

## QA
1. Install build; open the chat → window is 450×720.
2. Open the header menu (⋯) → "Clear Conversation" is on one line (LTR and RTL).
3. On an RTL site → menu opens inside the panel, not clipped.
4. Mobile viewport → widget still goes full-width/70vh.
Note: `artifact/hyve-lite.zip` is a stale pre-change build; regenerate via `npm ci && npm run build` + `npm run dist` before shipping.