### PR TITLE
fix: Qdrant credential crash, implied telemetry consent on Connect

### DIFF
--- a/inc/API.php
+++ b/inc/API.php
@@ -599,8 +599,12 @@ class API extends BaseAPI {
 			}
 		}
 
-		if ( Hyve_Connect::MODE_SELF === $mode && ( ( isset( $updated['qdrant_api_key'] ) && ! empty( $updated['qdrant_api_key'] ) ) || ( isset( $updated['qdrant_endpoint'] ) && ! empty( $updated['qdrant_endpoint'] ) ) ) ) {
-			$qdrant = new Qdrant_API( $data['qdrant_api_key'], $data['qdrant_endpoint'] );
+		if ( Hyve_Connect::MODE_SELF === $mode && ( ! empty( $updated['qdrant_api_key'] ) || ! empty( $updated['qdrant_endpoint'] ) ) ) {
+			if ( empty( $settings['qdrant_api_key'] ) || empty( $settings['qdrant_endpoint'] ) ) {
+				return $this->settings_response( [ 'error' => __( 'Both the Qdrant API key and the endpoint are required to connect.', 'hyve-lite' ) ] );
+			}
+
+			$qdrant = new Qdrant_API( $settings['qdrant_api_key'], $settings['qdrant_endpoint'] );
 			$init   = $qdrant->init();
 
 			if ( is_wp_error( $init ) ) {
@@ -617,14 +621,6 @@ class API extends BaseAPI {
 		}
 
 		Encryption::maybe_reset_key_check();
-
-		// Switching into Connect: push any existing self-hosted content up to the
-		// platform so the site does not start with an empty hosted KB. Runs on a
-		// cron batch; fresh/empty sites are a no-op.
-		if ( Hyve_Connect::MODE_CONNECT === $mode && Hyve_Connect::MODE_CONNECT !== $prev_mode ) {
-			Hyve_Connect::flush_stats();
-			$this->table->connect_start_sync();
-		}
 
 		// Switching into Connect: push any existing self-hosted content up to the
 		// platform so the site does not start with an empty hosted KB. Runs on a

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -62,6 +62,7 @@ class Main {
 		add_action( DB_Table::CONNECT_SYNC_HOOK, [ $this->table, 'connect_run_sync' ] );
 		add_action( DB_Table::CONNECT_DELETE_HOOK, [ $this->table, 'connect_run_deletes' ] );
 		add_filter( 'themeisle_sdk_enable_telemetry', '__return_true' );
+		add_filter( 'pre_option_hyve_lite_logger_flag', [ $this, 'force_connect_telemetry' ] );
 
 		add_filter( 'hyve_global_chat_enabled', [ $this, 'is_global_chat_enabled' ] );
 		add_filter( 'hyve_stats', [ $this, 'get_stats' ] );
@@ -1408,6 +1409,29 @@ class Main {
 		}
 
 		return 0.4;
+	}
+
+	/**
+	 * Force telemetry consent while Hyve Connect is active.
+	 *
+	 * Connect runs on the hosted platform, where usage data collection is part
+	 * of the service, so consent is implied for as long as the site stays
+	 * connected. The stored preference is untouched and applies again after a
+	 * disconnect. Reads the raw settings option because get_settings() resolves
+	 * the telemetry flag through this same filter.
+	 *
+	 * @param mixed $pre The pre-option value.
+	 *
+	 * @return mixed 'yes' while Connect is active, the given value otherwise.
+	 */
+	public function force_connect_telemetry( $pre ) {
+		$saved = get_option( 'hyve_settings', [] );
+
+		if ( is_array( $saved ) && isset( $saved['ai_mode'] ) && Hyve_Connect::MODE_CONNECT === $saved['ai_mode'] ) {
+			return 'yes';
+		}
+
+		return $pre;
 	}
 
 	/**

--- a/inc/Qdrant_API.php
+++ b/inc/Qdrant_API.php
@@ -40,9 +40,9 @@ class Qdrant_API {
 	public const ERROR_OPTION_KEY = 'hyve_qdrant_api_error';
 
 	/**
-	 * Qdrant Client.
-	 * 
-	 * @var Qdrant
+	 * Qdrant Client. Unset when the stored credentials are incomplete.
+	 *
+	 * @var Qdrant|null
 	 */
 	public $client;
 
@@ -139,14 +139,37 @@ class Qdrant_API {
 	}
 
 	/**
+	 * Get the configured client, or a WP_Error when it is not available.
+	 *
+	 * The constructor leaves the client unset when either credential is
+	 * missing, so every method that talks to Qdrant must fail gracefully
+	 * instead of passing null to the Qdrant library.
+	 *
+	 * @return Qdrant|\WP_Error
+	 */
+	private function ensure_client() {
+		if ( $this->client instanceof Qdrant ) {
+			return $this->client;
+		}
+
+		return new \WP_Error( 'qdrant_not_configured', __( 'Qdrant is not connected. Please check your API key and endpoint URL in the Integrations settings.', 'hyve-lite' ) );
+	}
+
+	/**
 	 * Check if collection exists.
-	 * 
+	 *
 	 * @return bool|\WP_Error
-	 */ 
+	 */
 	public function collection_exists() {
+		$client = $this->ensure_client();
+
+		if ( is_wp_error( $client ) ) {
+			return $client;
+		}
+
 		try {
-			
-			$response = ( new Collections( $this->client ) )->list();
+
+			$response = ( new Collections( $client ) )->list();
 			delete_option( self::ERROR_OPTION_KEY );
 			
 			if ( empty( $response['result'] ) || empty( $response['result']['collections'] ) || ! is_array( $response['result']['collections'] ) ) {
@@ -171,10 +194,16 @@ class Qdrant_API {
 	 * @return bool|\WP_Error
 	 */
 	public function create_collection() {
+		$client = $this->ensure_client();
+
+		if ( is_wp_error( $client ) ) {
+			return $client;
+		}
+
 		try {
 			$collection = new CreateCollection();
 			$collection->addVector( new VectorParams( 1536, VectorParams::DISTANCE_COSINE ), 'embeddings' );
-			$response = $this->client->collections( self::COLLECTION_NAME )->create( $collection );
+			$response = $client->collections( self::COLLECTION_NAME )->create( $collection );
 			delete_option( self::ERROR_OPTION_KEY );
 
 			return $response['result'];
@@ -196,8 +225,14 @@ class Qdrant_API {
 	 * @return bool|\WP_Error
 	 */
 	public function ensure_payload_index() {
+		$client = $this->ensure_client();
+
+		if ( is_wp_error( $client ) ) {
+			return $client;
+		}
+
 		try {
-			$this->client->collections( self::COLLECTION_NAME )->index()->create(
+			$client->collections( self::COLLECTION_NAME )->index()->create(
 				new CreateIndex( 'post_id', 'keyword' )
 			);
 			delete_option( self::ERROR_OPTION_KEY );
@@ -217,6 +252,12 @@ class Qdrant_API {
 	 * @return bool|\WP_Error
 	 */
 	public function add_point( $embeddings, $data ) {
+		$client = $this->ensure_client();
+
+		if ( is_wp_error( $client ) ) {
+			return $client;
+		}
+
 		try {
 			$points = new PointsStruct();
 
@@ -228,7 +269,7 @@ class Qdrant_API {
 				)
 			);
 
-			$response = $this->client->collections( self::COLLECTION_NAME )->points()->upsert( $points, [ 'wait' => 'true' ] );
+			$response = $client->collections( self::COLLECTION_NAME )->points()->upsert( $points, [ 'wait' => 'true' ] );
 
 			delete_option( self::ERROR_OPTION_KEY );
 
@@ -247,6 +288,12 @@ class Qdrant_API {
 	 * @return bool|\WP_Error
 	 */
 	public function add_points( $points ) {
+		$client = $this->ensure_client();
+
+		if ( is_wp_error( $client ) ) {
+			return $client;
+		}
+
 		try {
 			$points_struct = new PointsStruct();
 
@@ -260,7 +307,7 @@ class Qdrant_API {
 				);
 			}
 
-			$response = $this->client->collections( self::COLLECTION_NAME )->points()->upsert( $points_struct, [ 'wait' => 'true' ] );
+			$response = $client->collections( self::COLLECTION_NAME )->points()->upsert( $points_struct, [ 'wait' => 'true' ] );
 
 			delete_option( self::ERROR_OPTION_KEY );
 
@@ -278,8 +325,14 @@ class Qdrant_API {
 	 * @return bool|\WP_Error
 	 */
 	public function delete_point( $id ) {
+		$client = $this->ensure_client();
+
+		if ( is_wp_error( $client ) ) {
+			return $client;
+		}
+
 		try {
-			$response = $this->client->collections( self::COLLECTION_NAME )->points()->deleteByFilter(
+			$response = $client->collections( self::COLLECTION_NAME )->points()->deleteByFilter(
 				( new Filter() )->addMust(
 					new MatchString( 'post_id', (string) $id )
 				)
@@ -302,6 +355,12 @@ class Qdrant_API {
 	 * @return array<array<string, mixed>>|\WP_Error
 	 */
 	public function search( $embeddings, $score_threshold ) {
+		$client = $this->ensure_client();
+
+		if ( is_wp_error( $client ) ) {
+			return $client;
+		}
+
 		try {
 			$search   = (
 				new SearchRequest(
@@ -311,7 +370,7 @@ class Qdrant_API {
 			->setLimit( 10 )
 			->setScoreThreshold( $score_threshold )
 			->setWithPayload( true );
-			$response = $this->client->collections( self::COLLECTION_NAME )->points()->search( $search );
+			$response = $client->collections( self::COLLECTION_NAME )->points()->search( $search );
 
 			// Any completed search means the service recovered.
 			delete_option( self::ERROR_OPTION_KEY );
@@ -345,8 +404,14 @@ class Qdrant_API {
 	 * @return bool|\WP_Error
 	 */
 	public function disconnect() {
+		$client = $this->ensure_client();
+
+		if ( is_wp_error( $client ) ) {
+			return $client;
+		}
+
 		try {
-			$response = $this->client->collections( self::COLLECTION_NAME )->points()->deleteByFilter(
+			$response = $client->collections( self::COLLECTION_NAME )->points()->deleteByFilter(
 				( new Filter() )->addMust(
 					new MatchString( 'website_url', get_site_url() )
 				)

--- a/src/backend/screens/Connect.js
+++ b/src/backend/screens/Connect.js
@@ -663,6 +663,12 @@ export const ConnectPanel = () => {
 						) }
 					</li>
 				</ul>
+				<p className="hyve-next-card__hint">
+					{ __(
+						"Hyve Connect is a hosted service: the content you index and your visitors' chat messages are processed and stored on our platform so your assistant can answer, along with basic service data such as your site address and usage volumes.",
+						'hyve-lite'
+					) }
+				</p>
 			</div>
 
 			<div className="hyve-next-card__foot">

--- a/src/backend/screens/SettingsGeneral.js
+++ b/src/backend/screens/SettingsGeneral.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 
 import { ToggleControl } from '@wordpress/components';
 
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 import { useEffect, useState } from '@wordpress/element';
 
@@ -20,6 +20,10 @@ const SettingsGeneral = () => {
 	const { settings, isSaving, save } = useSaveSettings();
 
 	const { setSetting } = useDispatch( 'hyve' );
+
+	const isConnectActive = useSelect( ( select ) =>
+		select( 'hyve' ).isConnectActive()
+	);
 
 	// Toggles auto-save; the effect runs after the store update so save() posts
 	// the fresh value.
@@ -66,27 +70,29 @@ const SettingsGeneral = () => {
 				/>
 			</FieldRow>
 
-			<FieldRow
-				label={ __( 'Telemetry', 'hyve-lite' ) }
-				description={ __(
-					'Enable telemetry to help us improve the plugin by sending anonymous usage data. Data is private and not shared with third-party entities.',
-					'hyve-lite'
-				) }
-			>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={
-						telemetry
-							? __( 'Enabled', 'hyve-lite' )
-							: __( 'Disabled', 'hyve-lite' )
-					}
-					checked={ telemetry }
-					disabled={ isSaving }
-					onChange={ ( value ) =>
-						toggle( 'telemetry_enabled', value )
-					}
-				/>
-			</FieldRow>
+			{ ! isConnectActive && (
+				<FieldRow
+					label={ __( 'Telemetry', 'hyve-lite' ) }
+					description={ __(
+						'Enable telemetry to help us improve the plugin by sending anonymous usage data. Data is private and not shared with third-party entities.',
+						'hyve-lite'
+					) }
+				>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={
+							telemetry
+								? __( 'Enabled', 'hyve-lite' )
+								: __( 'Disabled', 'hyve-lite' )
+						}
+						checked={ telemetry }
+						disabled={ isSaving }
+						onChange={ ( value ) =>
+							toggle( 'telemetry_enabled', value )
+						}
+					/>
+				</FieldRow>
+			) }
 		</Card>
 	);
 };

--- a/tests/php/unit/tests/test-hyve-connect.php
+++ b/tests/php/unit/tests/test-hyve-connect.php
@@ -32,6 +32,7 @@ class HyveConnectTest extends WP_UnitTestCase {
 		remove_all_filters( 'hyve_connect_base_url' );
 		remove_all_actions( 'before_delete_post' );
 		delete_option( 'hyve_settings' );
+		delete_option( 'hyve_lite_logger_flag' );
 		delete_option( Hyve_Connect::SITE_TOKEN_OPTION );
 		delete_transient( 'hyve_connect_stats' );
 		parent::tearDown();
@@ -99,6 +100,24 @@ class HyveConnectTest extends WP_UnitTestCase {
 
 		$this->assertSame( Hyve_Connect::MODE_CONNECT, Hyve_Connect::get_mode() );
 		$this->assertTrue( Hyve_Connect::is_active() );
+	}
+
+	/**
+	 * Connect implies telemetry consent: the logger flag reads as opted in
+	 * while connected, without touching the stored preference, which applies
+	 * again after leaving Connect.
+	 */
+	public function test_connect_forces_telemetry_consent() {
+		update_option( 'hyve_lite_logger_flag', 'no' );
+		update_option( 'hyve_settings', [ 'ai_mode' => Hyve_Connect::MODE_CONNECT ] );
+
+		$this->assertSame( 'yes', get_option( 'hyve_lite_logger_flag' ) );
+		$this->assertTrue( \ThemeIsle\HyveLite\Main::get_settings()['telemetry_enabled'] );
+
+		update_option( 'hyve_settings', [ 'ai_mode' => Hyve_Connect::MODE_SELF ] );
+
+		$this->assertSame( 'no', get_option( 'hyve_lite_logger_flag' ) );
+		$this->assertFalse( \ThemeIsle\HyveLite\Main::get_settings()['telemetry_enabled'] );
 	}
 
 	/**

--- a/tests/php/unit/tests/test-qdrant.php
+++ b/tests/php/unit/tests/test-qdrant.php
@@ -79,6 +79,25 @@ class QdrantTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * With incomplete credentials the constructor never builds a client, so
+	 * every entry point must return a WP_Error instead of passing null to the
+	 * Qdrant library (uncaught TypeError, see #236).
+	 */
+	public function test_unconfigured_client_returns_wp_error() {
+		$qdrant = new Qdrant_API();
+
+		$this->assertWPError( $qdrant->init() );
+		$this->assertWPError( $qdrant->collection_exists() );
+		$this->assertWPError( $qdrant->create_collection() );
+		$this->assertWPError( $qdrant->ensure_payload_index() );
+		$this->assertWPError( $qdrant->add_point( [ 0.1 ], [] ) );
+		$this->assertWPError( $qdrant->add_points( [] ) );
+		$this->assertWPError( $qdrant->delete_point( 1 ) );
+		$this->assertWPError( $qdrant->search( [ 0.1 ], 0.4 ) );
+		$this->assertWPError( $qdrant->disconnect() );
+	}
+
+	/**
 	 * Known codes map to actionable messages; unknown codes return null.
 	 */
 	public function test_error_message_for_code() {

--- a/tests/php/unit/tests/test-settings-save.php
+++ b/tests/php/unit/tests/test-settings-save.php
@@ -70,6 +70,20 @@ class Test_Settings_Save extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Submitting one Qdrant credential while the other is missing reports a
+	 * validation error instead of reaching client initialization (see #236),
+	 * and the incomplete credentials are not stored.
+	 */
+	public function test_incomplete_qdrant_credentials_report_error() {
+		$response = (array) API::instance()->update_settings(
+			$this->request( [ 'qdrant_endpoint' => 'https://example.qdrant.io' ] )
+		)->get_data();
+
+		$this->assertArrayHasKey( 'error', $response );
+		$this->assertEmpty( Main::get_settings()['qdrant_endpoint'] );
+	}
+
+	/**
 	 * A save where every changed key validates reports a plain success.
 	 */
 	public function test_clean_save_reports_success() {


### PR DESCRIPTION
Fixes #236

### Qdrant: crash on incomplete credentials

Saving settings that enter the Qdrant initialization branch with only one credential (for example, an endpoint but no API key) left the client unset, and `collection_exists()` passed `null` to the Qdrant library, crashing the REST request with an uncaught `TypeError`.

- `API::update_settings()` now validates that the merged settings contain both the Qdrant API key and the endpoint before initializing the client, and returns a normal settings error response otherwise. It also no longer reads possibly unset keys from the raw request payload.
- `Qdrant_API` methods that talk to the service now go through `ensure_client()` and return a `WP_Error` when the client is not configured, so runtime paths (search, add, delete, disconnect) also fail gracefully if stored credentials become incomplete.
- Removed a duplicated block in `update_settings()` that scheduled the Connect content sync twice when switching into Connect mode.

### Telemetry: implied consent while on Hyve Connect

Connect runs on the hosted platform, where usage data collection is part of the service, so consent is taken as given while the site is connected.

- A `pre_option_hyve_lite_logger_flag` filter reads the flag as opted in while Connect is active. The stored preference is untouched and applies again after a disconnect.
- The telemetry toggle is hidden in the settings UI while connected, since the choice does not apply.
- The Connect page now discloses, before enabling, that indexed content, visitor chat messages, and basic service data are processed and stored on the platform.

### QA instructions

**Qdrant crash fix**

1. In self-hosted mode, go to the Integrations settings and enter only a Qdrant endpoint, leaving the API key empty. Save.
2. Expect the error notice "Both the Qdrant API key and the endpoint are required to connect." instead of a failed request, and confirm the incomplete value was not saved after a reload.
3. Repeat with only an API key and no endpoint; expect the same error.
4. Enter both valid credentials and save; Qdrant should connect as before.

**Telemetry consent on Connect**

1. In self-hosted mode, turn the Telemetry toggle off under Settings, General.
2. Open the Connect page and check the data-handling note above the enable button.
3. Enable Hyve Connect, then go back to Settings, General: the Telemetry toggle should no longer be shown.
4. Disconnect Hyve Connect and check again: the toggle should be back, showing your previous choice (off).
