### PR TITLE
feat: add debug traces and failure events to message history

### DIFF
--- a/inc/API.php
+++ b/inc/API.php
@@ -36,6 +36,30 @@ class API extends BaseAPI {
 	private $source_post_ids = [];
 
 	/**
+	 * Retrieval trace of the last knowledge base search: one row per chunk that
+	 * made it into the model context (source post ID, title, score, tokens).
+	 *
+	 * Recorded with the bot message in the conversation history so an answer —
+	 * or a refusal — can be debugged after the fact.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private $retrieval_trace = [];
+
+	/**
+	 * Debug information collected while preparing the current chat turn (the
+	 * retrieval query, threshold and matched chunks), attached to the recorded
+	 * bot message so the history shows what led to the reply.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $chat_debug = [];
+
+	/**
 	 * Ensures only one instance of the class is loaded.
 	 *
 	 * @return API An instance of the class.
@@ -1662,9 +1686,12 @@ class API extends BaseAPI {
 
 		$openai = OpenAI::instance();
 
+		$is_test = (bool) $request->get_param( 'is_test' );
+
 		$response = $openai->get_response( $run_id );
 
 		if ( is_wp_error( $response ) ) {
+			$this->record_error_event( (string) $thread_id, $record_id, (string) $response->get_error_code(), $this->get_error_message( $response ), $is_test );
 			return rest_ensure_response( [ 'error' => $this->get_error_message( $response ) ] );
 		}
 
@@ -1696,6 +1723,7 @@ class API extends BaseAPI {
 			$next = $openai->create_response_sync( $outputs, $thread_id );
 
 			if ( is_wp_error( $next ) ) {
+				$this->record_error_event( (string) $thread_id, $record_id, (string) $next->get_error_code(), $this->get_error_message( $next ), $is_test );
 				return rest_ensure_response( [ 'error' => $this->get_error_message( $next ) ] );
 			}
 
@@ -1711,6 +1739,9 @@ class API extends BaseAPI {
 
 		$status = $response->status;
 
+		// Kept before $response is reused for the reply text below.
+		$run_usage = isset( $response->usage ) ? $response->usage : null;
+
 		$message = array_filter(
 			$response->output,
 			function ( $message ) {
@@ -1724,6 +1755,7 @@ class API extends BaseAPI {
 		);
 
 		if ( empty( $message ) ) {
+			$this->record_error_event( (string) $thread_id, $record_id, 'no_reply', __( 'No messages found.', 'hyve-lite' ), $is_test );
 			return rest_ensure_response( [ 'error' => __( 'No messages found.', 'hyve-lite' ) ] );
 		}
 
@@ -1735,6 +1767,7 @@ class API extends BaseAPI {
 		$interpreted = OpenAI::interpret_chat_payload( $text, $settings['default_message'] );
 
 		if ( ! $interpreted['decoded'] ) {
+			$this->record_error_event( (string) $thread_id, $record_id, 'invalid_reply', __( 'No messages found.', 'hyve-lite' ), $is_test );
 			return rest_ensure_response( [ 'error' => __( 'No messages found.', 'hyve-lite' ) ] );
 		}
 
@@ -1778,6 +1811,32 @@ class API extends BaseAPI {
 			$response = $data['message'];
 		}
 
+		$extra = [
+			'mode'       => 'self_hosted',
+			'transport'  => 'poll',
+			'tools_used' => 0 < $iterations,
+		];
+
+		if ( 0 < $iterations ) {
+			$extra['tool_iterations'] = $iterations;
+		}
+
+		if ( $cancelled ) {
+			$extra['tools_aborted'] = true;
+		}
+
+		$usage = self::normalize_usage( $run_usage );
+
+		if ( null !== $usage ) {
+			$extra['usage'] = $usage;
+		}
+
+		$payload['debug'] = self::finalize_chat_debug(
+			$this->pull_debug_trace( $source_run_id ),
+			$extra,
+			$payload
+		);
+
 		// Skip recording for admin live-preview test chats (see send_chat).
 		if ( ! $request->get_param( 'is_test' ) ) {
 			do_action( 'hyve_chat_response', $run_id, $thread_id, $query, $record_id, $payload, $response );
@@ -1815,6 +1874,15 @@ class API extends BaseAPI {
 			$tokens_count = intval( $point['token_count'] );
 
 			if ( $tokens_threshold <= ( $current_token_count + $tokens_count ) ) {
+				// Matched the query but did not fit the context budget — traced
+				// so the Messages screen can show what the model never saw.
+				$this->retrieval_trace[] = [
+					'post_id'  => isset( $point['post_id'] ) ? intval( $point['post_id'] ) : 0,
+					'title'    => (string) $point['post_title'],
+					'score'    => isset( $point['score'] ) ? round( floatval( $point['score'] ), 4 ) : null,
+					'tokens'   => $tokens_count,
+					'included' => false,
+				];
 				continue;
 			}
 
@@ -1828,6 +1896,13 @@ class API extends BaseAPI {
 
 			$articles_embedded_data .= "\n ===START POST=== " . $point['post_title'] . ' - ' . $point['post_content'] . ' ===END POST===';
 			$current_token_count    += intval( $point['token_count'] );
+
+			$this->retrieval_trace[] = [
+				'post_id' => isset( $point['post_id'] ) ? intval( $point['post_id'] ) : 0,
+				'title'   => (string) $point['post_title'],
+				'score'   => isset( $point['score'] ) ? round( floatval( $point['score'] ), 4 ) : null,
+				'tokens'  => $tokens_count,
+			];
 		}
 
 		$this->source_post_ids = $this->rank_sources( $source_scores );
@@ -1857,6 +1932,7 @@ class API extends BaseAPI {
 		$items_per_page      = 50;
 		$saved_embeddings    = $this->table->get_embeddings( $offset, $items_per_page );
 		$matched_articles    = [];
+		$dropped_articles    = [];
 
 		do {
 			foreach ( $saved_embeddings as $data ) {
@@ -1912,6 +1988,7 @@ class API extends BaseAPI {
 						break;
 					}
 					$current_token_count -= $article['token_count'];
+					$dropped_articles[]   = $article;
 				}
 			}
 
@@ -1938,6 +2015,31 @@ class API extends BaseAPI {
 			}
 
 			$articles_embedded_data .= "\n ===START POST=== " . $article_data['post_title'] . ' - ' . $article_data['post_content'] . ' ===END POST===';
+
+			$this->retrieval_trace[] = [
+				'post_id' => intval( $post_id ),
+				'title'   => (string) $article_data['post_title'],
+				'score'   => round( floatval( $article['score'] ), 4 ),
+				'tokens'  => intval( $article['token_count'] ),
+			];
+		}
+
+		// Chunks that matched the query but were dropped for the context budget:
+		// traced (capped, they are already the weakest matches) so the Messages
+		// screen can show what the model never saw.
+		foreach ( array_slice( $dropped_articles, 0, 10 ) as $article ) {
+			$article_data = $this->table->get_post_data( $article['id'] );
+			if ( empty( $article_data ) ) {
+				continue;
+			}
+
+			$this->retrieval_trace[] = [
+				'post_id'  => intval( $this->table->get_post_id( $article['id'] ) ),
+				'title'    => (string) $article_data['post_title'],
+				'score'    => round( floatval( $article['score'] ), 4 ),
+				'tokens'   => intval( $article['token_count'] ),
+				'included' => false,
+			];
 		}
 
 		$this->source_post_ids = $this->rank_sources( $source_scores );
@@ -2003,6 +2105,7 @@ class API extends BaseAPI {
 	 */
 	public function search_knowledge_base( $message_vector, $similarity_score_threshold = 0.4, $tokens_threshold = 2000 ) {
 		$this->source_post_ids = [];
+		$this->retrieval_trace = [];
 
 		if ( Qdrant_API::is_active() ) {
 			return $this->search_knowledge_base_qdrant( $message_vector, $similarity_score_threshold, $tokens_threshold );
@@ -2355,6 +2458,10 @@ class API extends BaseAPI {
 		// OpenAI key otherwise). Throttle logged-out visitors per IP so a loop
 		// cannot drain the allowance; admins (the preview) are exempt.
 		if ( ! current_user_can( 'manage_options' ) && $this->chat_rate_limited() ) {
+			if ( ! $request->get_param( 'is_test' ) ) {
+				$this->record_rate_limited_event( $request->get_param( 'record_id' ) );
+			}
+
 			return rest_ensure_response(
 				[
 					'error' => __( 'You are sending messages too quickly. Please wait a moment and try again.', 'hyve-lite' ),
@@ -2366,6 +2473,18 @@ class API extends BaseAPI {
 		$prepared = $this->prepare_chat( $request );
 
 		if ( is_wp_error( $prepared ) ) {
+			$error_data = $prepared->get_error_data();
+
+			$this->record_chat_failure(
+				(string) $request->get_param( 'thread_id' ),
+				$request->get_param( 'record_id' ),
+				(string) $request->get_param( 'message' ),
+				(bool) $request->get_param( 'is_test' ),
+				(string) $prepared->get_error_code(),
+				$this->get_error_message( $prepared ),
+				is_array( $error_data ) && ! empty( $error_data['categories'] ) && is_array( $error_data['categories'] ) ? $error_data['categories'] : []
+			);
+
 			return rest_ensure_response(
 				[
 					'error' => $this->get_error_message( $prepared ),
@@ -2394,6 +2513,7 @@ class API extends BaseAPI {
 					'is_test'         => $is_test,
 					'source_post_ids' => $this->source_post_ids,
 					'page'            => isset( $prepared['page'] ) ? $prepared['page'] : null,
+					'debug'           => $this->chat_debug,
 				],
 				5 * MINUTE_IN_SECONDS
 			);
@@ -2419,6 +2539,15 @@ class API extends BaseAPI {
 		$query_run = $this->create_background_run( $prepared['context'], $prepared['message'], $thread_id );
 
 		if ( is_wp_error( $query_run ) ) {
+			$this->record_chat_failure(
+				(string) $thread_id,
+				$request_record,
+				$prepared['message'],
+				$is_test,
+				(string) $query_run->get_error_code(),
+				$this->get_error_message( $query_run )
+			);
+
 			return rest_ensure_response( [ 'error' => $this->get_error_message( $query_run ) ] );
 		}
 
@@ -2464,12 +2593,30 @@ class API extends BaseAPI {
 		$result = Hyve_Connect::instance()->chat( $payload );
 
 		if ( is_wp_error( $result ) ) {
+			$this->record_chat_failure(
+				(string) $prepared['thread_id'],
+				$record_id,
+				$prepared['message'],
+				$is_test,
+				(string) $result->get_error_code(),
+				$result->get_error_message()
+			);
+
 			return rest_ensure_response(
 				[
 					'error' => Hyve_Connect::visitor_message(),
 					'code'  => $result->get_error_code(),
 				]
 			);
+		}
+
+		// Close the latency clock here: the platform call is synchronous, and
+		// the poll hop that serves the buffered reply is not answering time.
+		$debug = $this->chat_debug;
+
+		if ( isset( $debug['started'] ) ) {
+			$debug['duration_ms'] = (int) round( ( microtime( true ) - (float) $debug['started'] ) * 1000 );
+			unset( $debug['started'] );
 		}
 
 		$thread_id = isset( $result['thread_id'] ) ? $result['thread_id'] : $prepared['thread_id'];
@@ -2488,6 +2635,7 @@ class API extends BaseAPI {
 				'thread_id' => $thread_id,
 				'record_id' => $record_id,
 				'is_test'   => $is_test,
+				'debug'     => $debug,
 				/**
 				 * Filters extra per-turn state carried from the request that ran
 				 * the Connect chat to the request that serves it to the widget
@@ -2593,6 +2741,17 @@ class API extends BaseAPI {
 			$final = $data['message'];
 		}
 
+		$job_debug = isset( $job['debug'] ) && is_array( $job['debug'] ) ? $job['debug'] : [];
+
+		$payload['debug'] = self::finalize_chat_debug(
+			array_merge( $job_debug, $this->connect_debug( $result ) ),
+			[
+				'mode'      => 'connect',
+				'transport' => 'poll',
+			],
+			$payload
+		);
+
 		if ( empty( $job['is_test'] ) ) {
 			do_action( 'hyve_chat_response', (string) $run_id, $job['thread_id'], $job['message'], $job['record_id'], $payload, $final );
 		}
@@ -2622,12 +2781,28 @@ class API extends BaseAPI {
 
 		$page = Page_Context::instance()->for_request( $request );
 
+		// The page the visitor chatted from, kept for the debug trace. Sent on
+		// every widget request; page context above only consumes it when the
+		// Page Awareness feature is enabled.
+		$page_url = $request->get_param( 'page_url' );
+		$page_url = is_string( $page_url ) && '' !== $page_url ? esc_url_raw( $page_url ) : '';
+
 		// Connect mode: moderation, embedding, retrieval, and thread minting all
 		// happen server-side inside hyve-chat, so there is no local prep. The
 		// platform mints the thread id on turn 1 and echoes it back.
 		if ( Hyve_Connect::is_active() ) {
 			$this->source_post_ids = [];
-			$thread_id             = $request->get_param( 'thread_id' );
+			$this->chat_debug      = [ 'started' => microtime( true ) ];
+
+			if ( '' !== $page_url ) {
+				$this->chat_debug['page'] = $page_url;
+			}
+
+			if ( $page ) {
+				$this->chat_debug['page_context'] = true;
+			}
+
+			$thread_id = $request->get_param( 'thread_id' );
 
 			return [
 				'thread_id' => $thread_id ? $thread_id : '',
@@ -2639,8 +2814,18 @@ class API extends BaseAPI {
 
 		$moderation = OpenAI::instance()->moderate_chunks( $message );
 
+		// An API failure is not a moderation verdict: surface it as a service
+		// error instead of telling the visitor their message was flagged.
+		if ( is_wp_error( $moderation ) ) {
+			return new \WP_Error( 'moderation_unavailable', __( 'Your message could not be processed. Please try again.', 'hyve-lite' ) );
+		}
+
 		if ( true !== $moderation ) {
-			return new \WP_Error( 'content_flagged', __( 'This message was flagged by OpenAI moderation and was not answered.', 'hyve-lite' ) );
+			return new \WP_Error(
+				'content_flagged',
+				__( 'This message was flagged by OpenAI moderation and was not answered.', 'hyve-lite' ),
+				[ 'categories' => $moderation ]
+			);
 		}
 
 		$openai          = OpenAI::instance();
@@ -2704,6 +2889,26 @@ class API extends BaseAPI {
 			);
 		}
 
+		// Everything retrieval decided for this turn, kept for the conversation
+		// history so a reply (or a refusal) can be traced back to what the
+		// search actually matched. The query is capped so a long history blend
+		// cannot bloat the stored thread meta.
+		$this->chat_debug = [
+			'query'     => mb_substr( $retrieval_query, 0, 2000 ),
+			'threshold' => (float) $similarity_score_threshold,
+			'context'   => $this->retrieval_trace,
+			'model'     => $openai->get_chat_model(),
+			'started'   => microtime( true ),
+		];
+
+		if ( '' !== $page_url ) {
+			$this->chat_debug['page'] = $page_url;
+		}
+
+		if ( $page ) {
+			$this->chat_debug['page_context'] = true;
+		}
+
 		$hash = hash( 'md5', strtolower( $message ) );
 		// TTL must outlast the slowest reply (streaming can run up to the 120s
 		// cURL cap) so the embedding is still available when hyve_chat_response
@@ -2751,6 +2956,302 @@ class API extends BaseAPI {
 		if ( ! empty( $this->source_post_ids ) && is_string( $query_run ) ) {
 			set_transient( 'hyve_source_' . $query_run, $this->source_post_ids, HOUR_IN_SECONDS );
 		}
+
+		// The reply lands in a later request (the poll), so the retrieval trace
+		// must survive the hop to be recorded with the bot message.
+		if ( ! empty( $this->chat_debug ) && is_string( $query_run ) ) {
+			set_transient( 'hyve_debug_' . $query_run, $this->chat_debug, HOUR_IN_SECONDS );
+		}
+
 		return $query_run;
+	}
+
+	/**
+	 * Read (and consume) the retrieval debug trace stashed for a background run.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $run_id The run ID the trace was stored under.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function pull_debug_trace( $run_id ) {
+		$transient_key = 'hyve_debug_' . $run_id;
+		$debug         = get_transient( $transient_key );
+		delete_transient( $transient_key );
+
+		return is_array( $debug ) ? $debug : [];
+	}
+
+	/**
+	 * Finalize the debug information recorded with a bot message in the
+	 * conversation history.
+	 *
+	 * Merges the retrieval trace collected when the turn was prepared with the
+	 * facts only known at reply time (mode, transport, whether tools ran), and
+	 * lets extensions add their own (the pro plugin adds the skills that ran).
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array<string, mixed> $debug   Debug info collected during retrieval.
+	 * @param array<string, mixed> $extra   Turn facts known at reply time.
+	 * @param array<string, mixed> $payload The interpreted model payload.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function finalize_chat_debug( $debug, $extra, $payload ) {
+		$debug = array_merge( $debug, $extra );
+
+		// Wall-clock time from the visitor's send to the recorded reply.
+		if ( isset( $debug['started'] ) ) {
+			$debug['duration_ms'] = (int) round( ( microtime( true ) - (float) $debug['started'] ) * 1000 );
+			unset( $debug['started'] );
+		}
+
+		// Follow-up suggestions the visitor was offered alongside the reply.
+		if ( ! empty( $payload['follow_ups'] ) && is_array( $payload['follow_ups'] ) ) {
+			$follow_ups = [];
+
+			foreach ( $payload['follow_ups'] as $follow_up ) {
+				if ( is_string( $follow_up ) && '' !== trim( $follow_up ) ) {
+					$follow_ups[] = mb_substr( $follow_up, 0, 200 );
+				}
+			}
+
+			if ( ! empty( $follow_ups ) ) {
+				$debug['follow_ups'] = $follow_ups;
+			}
+		}
+
+		// The model's raw reply when the visitor saw something else instead
+		// (the fallback message): without it, "what did the model actually
+		// say?" is unanswerable after the fact.
+		if (
+			isset( $payload['response'] ) &&
+			is_string( $payload['response'] ) &&
+			'' !== trim( $payload['response'] ) &&
+			empty( $payload['success'] )
+		) {
+			$debug['raw_reply'] = mb_substr( $payload['response'], 0, 500 );
+		}
+
+		/**
+		 * Filters the debug information recorded with a bot message in the
+		 * conversation history (Messages screen). The pro plugin uses this to
+		 * add the skills executed during the turn.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param array<string, mixed> $debug   Debug info for the turn.
+		 * @param array<string, mixed> $payload The interpreted model payload.
+		 */
+		return apply_filters( 'hyve_chat_debug', $debug, $payload );
+	}
+
+	/**
+	 * Record a failed chat turn in the conversation history.
+	 *
+	 * The visitor's message is recorded normally, then the failure is added as
+	 * an `event` entry — a divider line in the Messages screen, never a bot
+	 * bubble — so the owner can see that the visitor asked and got an error,
+	 * without the failure masquerading as a reply.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string               $thread_id  Conversation id ('' when none was minted yet).
+	 * @param int|string|null      $record_id  Existing thread post ID, when the conversation exists.
+	 * @param string               $message    The visitor's message.
+	 * @param bool                 $is_test    Admin live-preview chat (never recorded).
+	 * @param string               $code       The error code (content_flagged, openai_error, ...).
+	 * @param string               $detail     Human-readable detail, truncated for storage.
+	 * @param array<string, mixed> $categories Flagged moderation categories, when applicable.
+	 *
+	 * @return void
+	 */
+	public function record_chat_failure( $thread_id, $record_id, $message, $is_test, $code, $detail = '', $categories = [] ) {
+		if ( $is_test || '' === trim( (string) $message ) ) {
+			return;
+		}
+
+		$record_id = apply_filters( 'hyve_chat_request', (string) $thread_id, $record_id ? $record_id : null, (string) $message );
+
+		if ( ! $record_id ) {
+			return;
+		}
+
+		$event = 'content_flagged' === $code ? 'moderation_flagged' : 'chat_error';
+		$debug = [ 'code' => (string) $code ];
+
+		if ( 'moderation_flagged' === $event && ! empty( $categories ) ) {
+			$debug['categories'] = array_keys( $categories );
+			$debug['detail']     = implode( ', ', array_keys( $categories ) );
+		} elseif ( '' !== $detail ) {
+			$debug['detail'] = mb_substr( $detail, 0, 200 );
+		}
+
+		Threads::add_message(
+			intval( $record_id ),
+			[
+				'thread_id' => (string) $thread_id,
+				'sender'    => 'event',
+				'message'   => $event,
+				'debug'     => $debug,
+			]
+		);
+	}
+
+	/**
+	 * Record an error event on an already-recorded turn (the visitor message
+	 * landed earlier in the flow; only the failure marker is added).
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string          $thread_id Conversation id.
+	 * @param int|string|null $record_id Thread post ID.
+	 * @param string          $code      The error code.
+	 * @param string          $detail    Human-readable detail.
+	 * @param bool            $is_test   Admin live-preview chat (never recorded).
+	 *
+	 * @return void
+	 */
+	public function record_error_event( $thread_id, $record_id, $code, $detail = '', $is_test = false ) {
+		if ( $is_test || ! $record_id || 'hyve_threads' !== get_post_type( (int) $record_id ) ) {
+			return;
+		}
+
+		$debug = [ 'code' => (string) $code ];
+
+		if ( '' !== $detail ) {
+			$debug['detail'] = mb_substr( $detail, 0, 200 );
+		}
+
+		Threads::add_message(
+			(int) $record_id,
+			[
+				'thread_id' => (string) $thread_id,
+				'sender'    => 'event',
+				'message'   => 'chat_error',
+				'debug'     => $debug,
+			]
+		);
+	}
+
+	/**
+	 * Record a rate-limited attempt as an event on an existing thread.
+	 *
+	 * Deliberately narrow: nothing is written for visitors without an existing
+	 * conversation, and consecutive rate-limit events collapse into one, so
+	 * abusive traffic cannot grow the database through blocked requests.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param int|string|null $record_id Thread post ID from the request.
+	 *
+	 * @return bool Whether an event was recorded.
+	 */
+	public function record_rate_limited_event( $record_id ) {
+		$record_id = intval( $record_id );
+
+		if ( ! $record_id || 'hyve_threads' !== get_post_type( $record_id ) ) {
+			return false;
+		}
+
+		$entries = get_post_meta( $record_id, '_hyve_thread_data', true );
+		$last    = is_array( $entries ) && ! empty( $entries ) ? end( $entries ) : null;
+
+		if ( is_array( $last ) && 'event' === ( $last['sender'] ?? '' ) && 'rate_limited' === ( $last['message'] ?? '' ) ) {
+			return false;
+		}
+
+		Threads::add_message(
+			$record_id,
+			[
+				'thread_id' => (string) get_post_meta( $record_id, '_hyve_thread_id', true ),
+				'sender'    => 'event',
+				'message'   => 'rate_limited',
+			]
+		);
+
+		return true;
+	}
+
+	/**
+	 * Normalize a token-usage object/array into the stored debug shape.
+	 *
+	 * Accepts the OpenAI Responses API usage object (input_tokens /
+	 * output_tokens) or an equivalent array, and returns a compact
+	 * ['input' => int, 'output' => int] pair, or null when unreadable.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param object|array<string, mixed>|null $usage Raw usage data.
+	 *
+	 * @return array{input: int, output: int}|null
+	 */
+	public static function normalize_usage( $usage ) {
+		$usage = is_object( $usage ) ? (array) $usage : $usage;
+
+		if ( ! is_array( $usage ) ) {
+			return null;
+		}
+
+		$input  = $usage['input_tokens'] ?? $usage['input'] ?? $usage['prompt_tokens'] ?? null;
+		$output = $usage['output_tokens'] ?? $usage['output'] ?? $usage['completion_tokens'] ?? null;
+
+		if ( ! is_numeric( $input ) && ! is_numeric( $output ) ) {
+			return null;
+		}
+
+		return [
+			'input'  => (int) $input,
+			'output' => (int) $output,
+		];
+	}
+
+	/**
+	 * Build the debug trace for a Hyve Connect turn from the platform result.
+	 *
+	 * Retrieval runs remotely in Connect mode, so the recorded trace is limited
+	 * to what the platform reports back: the sources behind the answer.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array<string, mixed> $result The platform job result.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function connect_debug( $result ) {
+		$debug = [];
+
+		$usage = isset( $result['usage'] ) ? self::normalize_usage( $result['usage'] ) : null;
+
+		if ( null !== $usage ) {
+			$debug['usage'] = $usage;
+		}
+
+		if ( empty( $result['sources'] ) || ! is_array( $result['sources'] ) ) {
+			return $debug;
+		}
+
+		$context = [];
+
+		foreach ( $result['sources'] as $source ) {
+			if ( ! is_array( $source ) ) {
+				continue;
+			}
+
+			$context[] = [
+				'post_id' => isset( $source['id'] ) ? intval( $source['id'] ) : 0,
+				'title'   => isset( $source['title'] ) ? (string) $source['title'] : '',
+				'score'   => isset( $source['score'] ) ? round( floatval( $source['score'] ), 4 ) : null,
+				'tokens'  => isset( $source['tokens'] ) ? intval( $source['tokens'] ) : null,
+			];
+		}
+
+		if ( ! empty( $context ) ) {
+			$debug['context'] = $context;
+		}
+
+		return $debug;
 	}
 }

--- a/inc/OpenAI.php
+++ b/inc/OpenAI.php
@@ -302,6 +302,17 @@ PROMPT;
 	}
 
 	/**
+	 * Get the effective chat model used for completions.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return string
+	 */
+	public function get_chat_model() {
+		return $this->chat_model;
+	}
+
+	/**
 	 * Set whether request errors should be persisted as a service error notice.
 	 *
 	 * @param bool $persist Whether to persist errors.
@@ -823,7 +834,7 @@ PROMPT;
 	 * @param string                      $conversation Conversation id.
 	 * @param callable                    $on_delta     Receives each text delta (string).
 	 *
-	 * @return array{id:string,text:string,tool_calls:array<int,array{call_id:string,name:string,arguments:string}>}|\WP_Error
+	 * @return array{id:string,text:string,tool_calls:array<int,array{call_id:string,name:string,arguments:string}>,usage:object|null}|\WP_Error
 	 */
 	public function stream_response( $items, $conversation, $on_delta ) {
 		if ( ! $this->api_key ) {
@@ -848,8 +859,9 @@ PROMPT;
 		$sse_buffer  = '';
 		$stream_err  = null;
 		$tool_calls  = [];
+		$usage       = null;
 
-		$write = function ( $ch, $chunk ) use ( &$sse_buffer, &$assembled, &$response_id, &$stream_err, &$tool_calls, $on_delta ) {
+		$write = function ( $ch, $chunk ) use ( &$sse_buffer, &$assembled, &$response_id, &$stream_err, &$tool_calls, &$usage, $on_delta ) {
 			$sse_buffer .= $chunk;
 
 			while ( false !== ( $pos = strpos( $sse_buffer, "\n\n" ) ) ) {
@@ -884,6 +896,12 @@ PROMPT;
 
 				if ( isset( $event->response->id ) ) {
 					$response_id = $event->response->id;
+				}
+
+				// The terminal response.completed event carries the run's token
+				// usage; kept for the per-message debug trace.
+				if ( isset( $event->response->usage ) ) {
+					$usage = $event->response->usage;
 				}
 
 				if ( 'response.output_text.delta' === $event->type && isset( $event->delta ) && is_string( $event->delta ) ) {
@@ -959,6 +977,7 @@ PROMPT;
 			'id'         => $response_id,
 			'text'       => $assembled,
 			'tool_calls' => $tool_calls,
+			'usage'      => $usage,
 		];
 	}
 

--- a/inc/Stream.php
+++ b/inc/Stream.php
@@ -175,6 +175,7 @@ class Stream {
 		$is_test         = ! empty( $job['is_test'] );
 		$source_post_ids = isset( $job['source_post_ids'] ) ? $job['source_post_ids'] : [];
 		$page            = isset( $job['page'] ) && is_array( $job['page'] ) ? $job['page'] : null;
+		$debug           = isset( $job['debug'] ) && is_array( $job['debug'] ) ? $job['debug'] : [];
 
 		Main::add_labels_to_default_settings();
 		$settings        = Main::get_settings();
@@ -183,7 +184,7 @@ class Stream {
 		$this->open_stream();
 
 		if ( Hyve_Connect::is_active() ) {
-			$this->stream_connect( $message, $thread_id, $record_id, $is_test, $settings, $default_message, $page );
+			$this->stream_connect( $message, $thread_id, $record_id, $is_test, $settings, $default_message, $page, $debug );
 			exit;
 		}
 
@@ -214,9 +215,13 @@ class Stream {
 			}
 		};
 
-		$result     = null;
-		$cancelled  = false;
-		$used_tools = false;
+		$result      = null;
+		$cancelled   = false;
+		$used_tools  = false;
+		$tool_rounds = 0;
+		$usage_in    = 0;
+		$usage_out   = 0;
+		$has_usage   = false;
 
 		for ( $i = 0; ; $i++ ) {
 			$raw         = '';
@@ -226,8 +231,22 @@ class Stream {
 			$result = OpenAI::instance()->stream_response( $items, $thread_id, $on_delta );
 
 			if ( is_wp_error( $result ) ) {
+				// The user message is only recorded when a reply lands, so a
+				// failed stream must record the turn itself: the message plus
+				// an error event, never a bot bubble.
+				API::instance()->record_chat_failure( $thread_id, $record_id, $message, $is_test, (string) $result->get_error_code(), $result->get_error_message() );
 				$this->send_event( 'error', [ 'message' => $result->get_error_message() ] );
 				exit;
+			}
+
+			// Sum usage across tool round-trips so the recorded trace reflects
+			// the whole turn, not only the closing response.
+			$run_usage = API::normalize_usage( isset( $result['usage'] ) ? $result['usage'] : null );
+
+			if ( null !== $run_usage ) {
+				$has_usage  = true;
+				$usage_in  += $run_usage['input'];
+				$usage_out += $run_usage['output'];
 			}
 
 			$tool_calls = $result['tool_calls'];
@@ -263,7 +282,8 @@ class Stream {
 			$this->send_event( 'status', [ 'state' => 'tool' ] );
 
 			$used_tools = true;
-			$items      = $outputs;
+			++$tool_rounds;
+			$items = $outputs;
 		}
 
 		if ( $cancelled ) {
@@ -357,6 +377,29 @@ class Stream {
 			$final = $data['message'];
 		}
 
+		$extra = [
+			'mode'       => 'self_hosted',
+			'transport'  => 'stream',
+			'tools_used' => $used_tools,
+		];
+
+		if ( 0 < $tool_rounds ) {
+			$extra['tool_iterations'] = $tool_rounds;
+		}
+
+		if ( $cancelled ) {
+			$extra['tools_aborted'] = true;
+		}
+
+		if ( $has_usage ) {
+			$extra['usage'] = [
+				'input'  => $usage_in,
+				'output' => $usage_out,
+			];
+		}
+
+		$payload['debug'] = API::finalize_chat_debug( $debug, $extra, $payload );
+
 		if ( ! $is_test ) {
 			do_action( 'hyve_chat_response', $result['id'], $thread_id, $message, $record_id, $payload, $final );
 		}
@@ -381,10 +424,11 @@ class Stream {
 	 * @param array<string, mixed>      $settings        Plugin settings.
 	 * @param string                    $default_message Fallback shown when the model cannot answer.
 	 * @param array<string, mixed>|null $page            Current page payload (see Page_Context::payload()).
+	 * @param array<string, mixed>      $debug           Debug trace collected when the turn was prepared.
 	 *
 	 * @return void
 	 */
-	private function stream_connect( $message, $thread_id, $record_id, $is_test, $settings, $default_message, $page = null ) {
+	private function stream_connect( $message, $thread_id, $record_id, $is_test, $settings, $default_message, $page = null, $debug = [] ) {
 		$sources = [];
 
 		$on_event = function ( $event, $data ) use ( &$sources ) {
@@ -412,6 +456,8 @@ class Stream {
 		$result = Hyve_Connect::instance()->stream_chat( $payload, $on_event );
 
 		if ( is_wp_error( $result ) ) {
+			API::instance()->record_chat_failure( $thread_id, $record_id, $message, $is_test, (string) $result->get_error_code(), $result->get_error_message() );
+
 			$error_code = $result->get_error_code();
 
 			// An empty/purged KB is visitor-facing parity with self-hosted: show
@@ -487,6 +533,15 @@ class Stream {
 		if ( isset( $data['message'] ) && is_string( $data['message'] ) ) {
 			$final = $data['message'];
 		}
+
+		$payload['debug'] = API::finalize_chat_debug(
+			array_merge( $debug, API::instance()->connect_debug( $result ) ),
+			[
+				'mode'      => 'connect',
+				'transport' => 'stream',
+			],
+			$payload
+		);
 
 		if ( ! $is_test ) {
 			do_action( 'hyve_chat_response', $thread, $thread, $message, $record_id, $payload, $final );

--- a/inc/Threads.php
+++ b/inc/Threads.php
@@ -84,6 +84,15 @@ class Threads {
 			return;
 		}
 
+		// The debug trace explains the reply after the fact: whether the model
+		// answered, what the retrieval matched and which tools ran. Without it a
+		// refusal is indistinguishable from a genuine knowledge gap.
+		$debug = isset( $message['debug'] ) && is_array( $message['debug'] ) ? $message['debug'] : [];
+
+		if ( isset( $message['success'] ) ) {
+			$debug['answered'] = (bool) $message['success'];
+		}
+
 		self::add_message(
 			intval( $record_id ),
 			[
@@ -91,6 +100,7 @@ class Threads {
 				'sender'    => 'bot',
 				'message'   => wp_kses_post( $response ),
 				'display'   => isset( $message['display'] ) && is_array( $message['display'] ) ? $message['display'] : null,
+				'debug'     => ! empty( $debug ) ? $debug : null,
 			]
 		);
 	}
@@ -131,7 +141,9 @@ class Threads {
 
 	/**
 	 * Build a stored transcript entry, carrying an optional `display` (skill
-	 * cards or choices) alongside the message so history matches what was shown.
+	 * cards or choices) alongside the message so history matches what was shown,
+	 * and an optional `debug` trace (answered flag, retrieval sources and
+	 * scores, tools) so the reply can be explained after the fact.
 	 *
 	 * @param array<string, mixed> $data The message data.
 	 *
@@ -146,6 +158,10 @@ class Threads {
 
 		if ( ! empty( $data['display'] ) && is_array( $data['display'] ) ) {
 			$entry['display'] = $data['display'];
+		}
+
+		if ( ! empty( $data['debug'] ) && is_array( $data['debug'] ) ) {
+			$entry['debug'] = $data['debug'];
 		}
 
 		return $entry;
@@ -205,7 +221,14 @@ class Threads {
 		$thread_id = get_post_meta( $post_id, '_hyve_thread_id', true );
 
 		if ( $thread_id !== $data['thread_id'] ) {
-			return self::create_thread( $data['message'], $data );
+			// A failed first turn records the thread before any conversation
+			// is minted, leaving an empty placeholder id. Adopt the real id
+			// on the next successful turn instead of forking a new thread.
+			if ( '' === (string) $thread_id && '' !== (string) $data['thread_id'] ) {
+				update_post_meta( $post_id, '_hyve_thread_id', $data['thread_id'] );
+			} else {
+				return self::create_thread( $data['message'], $data );
+			}
 		}
 
 		$thread_data = get_post_meta( $post_id, '_hyve_thread_data', true );

--- a/src/backend/screens/Messages.js
+++ b/src/backend/screens/Messages.js
@@ -5,11 +5,13 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 
 import apiFetch from '@wordpress/api-fetch';
 
-import { Button, Modal, Spinner } from '@wordpress/components';
+import { Button, Modal, Spinner, Tooltip } from '@wordpress/components';
 
 import { useDispatch } from '@wordpress/data';
 
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { Fragment, useEffect, useRef, useState } from '@wordpress/element';
+
+import { decodeEntities } from '@wordpress/html-entities';
 
 import { lock } from '@wordpress/icons';
 
@@ -431,6 +433,456 @@ const LeadsPanel = ( { item } ) => {
 
 const EVENT_LABELS = {
 	contact_form: __( 'Visitor submitted the contact form', 'hyve-lite' ),
+	moderation_flagged: __(
+		'Message was flagged by moderation — no reply was sent',
+		'hyve-lite'
+	),
+	rate_limited: __(
+		'Visitor hit the rate limit — the message was not answered',
+		'hyve-lite'
+	),
+	chat_error: __( 'The reply failed with an error', 'hyve-lite' ),
+};
+
+const MODE_LABELS = {
+	self_hosted: __( 'Self-hosted', 'hyve-lite' ),
+	connect: __( 'Hyve Connect', 'hyve-lite' ),
+};
+
+const clampPercent = ( value ) => Math.max( 0, Math.min( 100, value * 100 ) );
+
+const formatDuration = ( ms ) =>
+	1000 > ms ? `${ ms }ms` : `${ ( ms / 1000 ).toFixed( 1 ) }s`;
+
+// A ledger label with a hoverable "?" explaining what the field means.
+const DebugKey = ( { label, help } ) => (
+	<span className="hyve-next-debug__key">
+		{ label }
+		<Tooltip text={ help }>
+			<span
+				className="hyve-next-debug__help"
+				tabIndex={ 0 }
+				aria-label={ help }
+			>
+				?
+			</span>
+		</Tooltip>
+	</span>
+);
+
+// Trace for a bot reply (what retrieval matched and why): folded into the
+// timestamp line ("12:31 pm · Not answered · 9 sources · Show trace") so
+// transcripts stay clean, expanding into a label/value ledger where each
+// source carries a score bar with a tick at the similarity threshold.
+const MessageDebug = ( { debug, time } ) => {
+	const [ isOpen, setOpen ] = useState( false );
+
+	const sources = (
+		Array.isArray( debug.context ) ? [ ...debug.context ] : []
+	).sort( ( a, b ) => ( b.score ?? 0 ) - ( a.score ?? 0 ) );
+	const skills = Array.isArray( debug.skills ) ? debug.skills : [];
+	const skillCalls = Array.isArray( debug.skill_calls )
+		? debug.skill_calls
+		: [];
+	const followUps = Array.isArray( debug.follow_ups ) ? debug.follow_ups : [];
+	const threshold =
+		'number' === typeof debug.threshold ? debug.threshold : null;
+	const usage = debug.usage;
+	const includedCount = sources.filter(
+		( source ) => false !== source.included
+	).length;
+	const hasDropped = includedCount < sources.length;
+	const topIndex = sources.findIndex(
+		( source ) => false !== source.included
+	);
+
+	return (
+		<div className="hyve-next-debug">
+			<div className="hyve-next-debug__line">
+				<time>{ timeOfDay( time ) }</time>
+				{ false === debug.answered && (
+					<>
+						<span aria-hidden="true">·</span>
+						<span className="hyve-next-debug__warn">
+							{ __( 'Not answered', 'hyve-lite' ) }
+						</span>
+					</>
+				) }
+				<span aria-hidden="true">·</span>
+				<span>
+					{ sprintf(
+						/* translators: %d: number of knowledge base sources behind the answer. */
+						_n(
+							'%d source',
+							'%d sources',
+							includedCount,
+							'hyve-lite'
+						),
+						includedCount
+					) }
+				</span>
+				<span aria-hidden="true">·</span>
+				<button
+					type="button"
+					className="hyve-next-debug__toggle"
+					aria-expanded={ isOpen }
+					onClick={ () => setOpen( ! isOpen ) }
+				>
+					{ isOpen
+						? __( 'Hide trace', 'hyve-lite' )
+						: __( 'Show trace', 'hyve-lite' ) }
+				</button>
+			</div>
+
+			{ isOpen && (
+				<div className="hyve-next-debug__panel">
+					{ MODE_LABELS[ debug.mode ] && (
+						<div className="hyve-next-debug__row">
+							<DebugKey
+								label={ __( 'Answered by', 'hyve-lite' ) }
+								help={ __(
+									'Where the reply was generated: on this site (self-hosted) or on the Hyve Connect platform, and whether it was streamed or polled.',
+									'hyve-lite'
+								) }
+							/>
+							<span className="hyve-next-debug__val">
+								{ MODE_LABELS[ debug.mode ] }
+								{ debug.transport && ` · ${ debug.transport }` }
+							</span>
+						</div>
+					) }
+
+					{ Boolean( debug.model ) && (
+						<div className="hyve-next-debug__row">
+							<DebugKey
+								label={ __( 'Model', 'hyve-lite' ) }
+								help={ __(
+									'The AI model that generated this reply.',
+									'hyve-lite'
+								) }
+							/>
+							<span className="hyve-next-debug__val">
+								{ debug.model }
+							</span>
+						</div>
+					) }
+
+					{ 'number' === typeof debug.duration_ms && (
+						<div className="hyve-next-debug__row">
+							<DebugKey
+								label={ __( 'Latency', 'hyve-lite' ) }
+								help={ __(
+									'Time from the visitor sending the message to the reply being recorded.',
+									'hyve-lite'
+								) }
+							/>
+							<span className="hyve-next-debug__val">
+								{ formatDuration( debug.duration_ms ) }
+							</span>
+						</div>
+					) }
+
+					{ usage &&
+						( 'number' === typeof usage.input ||
+							'number' === typeof usage.output ) && (
+							<div className="hyve-next-debug__row">
+								<DebugKey
+									label={ __( 'Tokens', 'hyve-lite' ) }
+									help={ __(
+										'OpenAI tokens spent on this reply: prompt (in) and completion (out). Tool round trips are included.',
+										'hyve-lite'
+									) }
+								/>
+								<span className="hyve-next-debug__val">
+									{ sprintf(
+										/* translators: 1: prompt token count, 2: completion token count. */
+										__( '%1$s in · %2$s out', 'hyve-lite' ),
+										Number(
+											usage.input ?? 0
+										).toLocaleString(),
+										Number(
+											usage.output ?? 0
+										).toLocaleString()
+									) }
+								</span>
+							</div>
+						) }
+
+					{ null !== threshold && (
+						<div className="hyve-next-debug__row">
+							<DebugKey
+								label={ __( 'Threshold', 'hyve-lite' ) }
+								help={ __(
+									'The minimum similarity score a knowledge base chunk needed to be used as context for this reply. Configurable in Settings → AI.',
+									'hyve-lite'
+								) }
+							/>
+							<span className="hyve-next-debug__val">
+								{ threshold }
+							</span>
+						</div>
+					) }
+
+					{ ( Boolean( debug.tools_used ) || 0 < skills.length ) && (
+						<div className="hyve-next-debug__row">
+							<DebugKey
+								label={ __( 'Skills', 'hyve-lite' ) }
+								help={ __(
+									'Skills the assistant ran while composing this reply, such as live lookups. A skill-driven answer is grounded in the skill result rather than the knowledge base.',
+									'hyve-lite'
+								) }
+							/>
+							<span className="hyve-next-debug__val">
+								{ 0 < skills.length
+									? skills.join( ', ' )
+									: __( 'Yes', 'hyve-lite' ) }
+								{ Boolean( debug.tool_iterations ) &&
+									` · ${ sprintf(
+										/* translators: %d: number of tool round trips in this reply. */
+										_n(
+											'%d round trip',
+											'%d round trips',
+											debug.tool_iterations,
+											'hyve-lite'
+										),
+										debug.tool_iterations
+									) }` }
+								{ debug.tools_aborted &&
+									` · ${ __( 'aborted', 'hyve-lite' ) }` }
+								{ 0 < skillCalls.length && (
+									<span className="hyve-next-debug__calls">
+										{ skillCalls.map( ( call, i ) => (
+											<span
+												key={ i }
+												className="hyve-next-debug__call"
+											>
+												<code>
+													{ call.name }
+													{ call.args
+														? `(${ call.args })`
+														: '()' }
+												</code>
+												{ Boolean( call.output ) && (
+													<span className="hyve-next-debug__call-output">
+														{ call.output }
+													</span>
+												) }
+											</span>
+										) ) }
+									</span>
+								) }
+							</span>
+						</div>
+					) }
+
+					{ isSafeUrl( debug.page ) && (
+						<div className="hyve-next-debug__row">
+							<DebugKey
+								label={ __( 'Page', 'hyve-lite' ) }
+								help={ __(
+									'The page the visitor was on when they sent this message.',
+									'hyve-lite'
+								) }
+							/>
+							<span className="hyve-next-debug__val">
+								<a
+									href={ debug.page }
+									target="_blank"
+									rel="noreferrer"
+								>
+									{ debug.page.replace(
+										/^https?:\/\/[^/]+/,
+										''
+									) || debug.page }
+								</a>
+								{ debug.page_context &&
+									` · ${ __(
+										'content included as context',
+										'hyve-lite'
+									) }` }
+							</span>
+						</div>
+					) }
+
+					{ debug.page_context && ! isSafeUrl( debug.page ) && (
+						<div className="hyve-next-debug__row">
+							<DebugKey
+								label={ __( 'Page context', 'hyve-lite' ) }
+								help={ __(
+									'The content of the page the visitor was on was included as extra context for this reply.',
+									'hyve-lite'
+								) }
+							/>
+							<span className="hyve-next-debug__val">
+								{ __( 'Included', 'hyve-lite' ) }
+							</span>
+						</div>
+					) }
+
+					{ 0 < followUps.length && (
+						<div className="hyve-next-debug__row">
+							<DebugKey
+								label={ __( 'Follow-ups', 'hyve-lite' ) }
+								help={ __(
+									'Follow-up questions suggested to the visitor alongside this reply.',
+									'hyve-lite'
+								) }
+							/>
+							<span className="hyve-next-debug__val">
+								{ followUps.map( ( followUp, i ) => (
+									<span
+										key={ i }
+										className="hyve-next-debug__followup"
+									>
+										{ followUp }
+									</span>
+								) ) }
+							</span>
+						</div>
+					) }
+
+					<div className="hyve-next-debug__row">
+						<DebugKey
+							label={ __( 'Sources', 'hyve-lite' ) }
+							help={ __(
+								'Knowledge base content sent to the model as context, with how closely each piece matched the question (0–1). Hover a title for its size in tokens. The best-scoring sources may also be shown to the visitor as source links.',
+								'hyve-lite'
+							) }
+						/>
+						{ 0 < sources.length ? (
+							<span className="hyve-next-debug__val hyve-next-debug__sources">
+								{ sources.map( ( source, i ) => {
+									const score =
+										'number' === typeof source.score
+											? source.score
+											: null;
+									const dropped = false === source.included;
+									const droppedClass = dropped
+										? ' is-dropped'
+										: '';
+
+									return (
+										<Fragment key={ i }>
+											<span
+												className={ `hyve-next-debug__source-title${ droppedClass }` }
+												title={
+													source.tokens
+														? sprintf(
+																/* translators: %d: token count of the source chunk. */
+																__(
+																	'%d tokens',
+																	'hyve-lite'
+																),
+																source.tokens
+														  )
+														: undefined
+												}
+											>
+												{ decodeEntities(
+													source.title
+												) || `#${ source.post_id }` }
+											</span>
+											<span
+												className={ `hyve-next-debug__bar${
+													null === score &&
+													null === threshold
+														? ' is-empty'
+														: ''
+												}` }
+											>
+												{ null !== threshold && (
+													<span
+														className="hyve-next-debug__tick"
+														style={ {
+															left: `${ clampPercent(
+																threshold
+															) }%`,
+														} }
+													></span>
+												) }
+												{ null !== score && (
+													<span
+														className={ `hyve-next-debug__fill${
+															topIndex === i
+																? ' is-top'
+																: ''
+														}${ droppedClass }` }
+														style={ {
+															width: `${ clampPercent(
+																score
+															) }%`,
+														} }
+													></span>
+												) }
+											</span>
+											<span
+												className={ `hyve-next-debug__score${ droppedClass }` }
+											>
+												{ null !== score
+													? score.toFixed( 2 )
+													: '—' }
+											</span>
+										</Fragment>
+									);
+								} ) }
+								{ null !== threshold && (
+									<span className="hyve-next-debug__note">
+										{ sprintf(
+											/* translators: %s: the similarity threshold value. */
+											__(
+												'| marks the similarity threshold (%s)',
+												'hyve-lite'
+											),
+											threshold
+										) }
+										{ hasDropped &&
+											` ${ __(
+												'Dimmed sources matched but were left out: the context budget was full.',
+												'hyve-lite'
+											) }` }
+									</span>
+								) }
+							</span>
+						) : (
+							<span className="hyve-next-debug__val">
+								{ __( 'None matched', 'hyve-lite' ) }
+							</span>
+						) }
+					</div>
+
+					{ Boolean( debug.raw_reply ) && (
+						<div className="hyve-next-debug__row">
+							<DebugKey
+								label={ __( 'Model reply', 'hyve-lite' ) }
+								help={ __(
+									'What the model actually returned for this turn. The visitor saw the fallback message instead.',
+									'hyve-lite'
+								) }
+							/>
+							<pre className="hyve-next-debug__query">
+								{ debug.raw_reply }
+							</pre>
+						</div>
+					) }
+
+					{ Boolean( debug.query ) && (
+						<div className="hyve-next-debug__row">
+							<DebugKey
+								label={ __( 'Query', 'hyve-lite' ) }
+								help={ __(
+									'The exact text used to search the knowledge base: the question blended with recent turns of the conversation, so follow-ups keep their topic.',
+									'hyve-lite'
+								) }
+							/>
+							<pre className="hyve-next-debug__query">
+								{ debug.query }
+							</pre>
+						</div>
+					) }
+				</div>
+			) }
+		</div>
+	);
 };
 
 const ThreadView = ( { item } ) => {
@@ -618,9 +1070,17 @@ const ThreadView = ( { item } ) => {
 												) }
 											</div>
 										) }
-										<time>
-											{ timeOfDay( message.time ) }
-										</time>
+										{ message.debug &&
+										'object' === typeof message.debug ? (
+											<MessageDebug
+												debug={ message.debug }
+												time={ message.time }
+											/>
+										) : (
+											<time>
+												{ timeOfDay( message.time ) }
+											</time>
+										) }
 									</div>
 								);
 							}
@@ -652,25 +1112,9 @@ const ThreadView = ( { item } ) => {
 									>
 										<span>
 											{ EVENT_LABELS[ message.message ] }
-										</span>
-										<time>
-											{ timeOfDay( message.time ) }
-										</time>
-									</div>
-								);
-							}
-
-							if (
-								'event' === message.sender &&
-								EVENT_LABELS[ message.message ]
-							) {
-								return (
-									<div
-										key={ index }
-										className="hyve-next-thread__event"
-									>
-										<span>
-											{ EVENT_LABELS[ message.message ] }
+											{ message.debug?.detail
+												? ` · ${ message.debug.detail }`
+												: '' }
 										</span>
 										<time>
 											{ timeOfDay( message.time ) }

--- a/src/backend/style.scss
+++ b/src/backend/style.scss
@@ -1342,6 +1342,226 @@ p.hyve-next-notice__text {
 	}
 }
 
+/* Per-reply trace, folded into the timestamp line ("12:31 pm · Not answered ·
+   9 sources · Show trace") so transcripts stay clean. The expanded ledger uses
+   the same label/value grid as the lead detail rows, with a score bar per
+   source and a tick marking the similarity threshold. */
+.hyve-next-debug {
+	font-size: 12px;
+	max-width: 560px;
+}
+
+.hyve-next-debug__line {
+	align-items: center;
+	color: var(--hyve-muted);
+	display: flex;
+	flex-wrap: wrap;
+	font-size: 10.5px;
+	gap: 5px;
+	margin-top: 3px;
+	padding: 0 2px;
+
+	time {
+		margin: 0;
+		padding: 0;
+	}
+}
+
+.hyve-next-debug__warn {
+	color: var(--hyve-warn);
+	font-weight: 600;
+}
+
+.hyve-next-debug__toggle {
+	background: none;
+	border: 0;
+	color: var(--hyve-wp-blue);
+	cursor: pointer;
+	font: inherit;
+	padding: 0;
+
+	&:hover,
+	&:focus-visible {
+		text-decoration: underline;
+	}
+}
+
+.hyve-next-debug__panel {
+	background: var(--hyve-surface-2);
+	border: 1px solid var(--hyve-border);
+	border-radius: var(--hyve-radius);
+	margin-top: 6px;
+	padding: 4px 14px;
+}
+
+.hyve-next-debug__row {
+	border-top: 1px solid var(--hyve-border);
+	display: grid;
+	gap: 16px;
+	grid-template-columns: 120px minmax(0, 1fr);
+	padding: 8px 0;
+
+	&:first-child {
+		border-top: 0;
+	}
+}
+
+.hyve-next-debug__key {
+	color: var(--hyve-muted);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.03em;
+	padding-top: 1px;
+	text-transform: uppercase;
+}
+
+.hyve-next-debug__val {
+	overflow-wrap: anywhere;
+}
+
+.hyve-next-debug__help {
+	align-items: center;
+	border: 1px solid var(--hyve-border);
+	border-radius: 50%;
+	color: var(--hyve-muted);
+	cursor: help;
+	display: inline-flex;
+	font-size: 9px;
+	font-weight: 700;
+	height: 13px;
+	justify-content: center;
+	letter-spacing: 0;
+	margin-left: 5px;
+	vertical-align: text-bottom;
+	width: 13px;
+}
+
+.hyve-next-debug__sources {
+	align-items: center;
+	column-gap: 10px;
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 120px 40px;
+	row-gap: 5px;
+}
+
+.hyve-next-debug__source-title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+/* Sources that matched the query but were dropped for the context budget. */
+.hyve-next-debug__source-title.is-dropped,
+.hyve-next-debug__score.is-dropped {
+	opacity: 0.55;
+}
+
+.hyve-next-debug__fill.is-dropped {
+	background: var(--hyve-faint, #c3c4c7);
+}
+
+/* One executed skill call: name(args) plus a truncated output. */
+.hyve-next-debug__calls {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin-top: 6px;
+}
+
+.hyve-next-debug__call {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+
+	code {
+		background: var(--hyve-surface);
+		border: 1px solid var(--hyve-border);
+		border-radius: var(--hyve-radius);
+		font-size: 11px;
+		padding: 1px 5px;
+		width: fit-content;
+	}
+}
+
+.hyve-next-debug__call-output {
+	color: var(--hyve-muted);
+	font-family: ui-monospace, Menlo, Consolas, monospace;
+	font-size: 10.5px;
+	overflow-wrap: anywhere;
+}
+
+.hyve-next-debug__followup {
+	display: block;
+
+	&::before {
+		color: var(--hyve-muted);
+		content: "– ";
+	}
+}
+
+.hyve-next-debug__bar {
+	background: var(--hyve-border);
+	border-radius: 2px;
+	height: 5px;
+	position: relative;
+
+	// Hyve Connect reports sources without scores: keep the grid cell but
+	// draw nothing, so a missing score doesn't read as a zero score.
+	&.is-empty {
+		background: transparent;
+	}
+}
+
+.hyve-next-debug__fill {
+	background: #7da7cd;
+	border-radius: 2px;
+	height: 100%;
+	left: 0;
+	position: absolute;
+	top: 0;
+
+	&.is-top {
+		background: var(--hyve-wp-blue);
+	}
+}
+
+.hyve-next-debug__tick {
+	background: #d63638;
+	bottom: -2px;
+	position: absolute;
+	top: -2px;
+	width: 1px;
+}
+
+.hyve-next-debug__score {
+	color: var(--hyve-muted);
+	font-variant-numeric: tabular-nums;
+	text-align: right;
+}
+
+.hyve-next-debug__note {
+	color: var(--hyve-muted);
+	font-size: 11px;
+	grid-column: 1 / -1;
+}
+
+/* Outranks the dark transcript code-block styling on .hyve-next-bubble pre. */
+.hyve-next-debug pre.hyve-next-debug__query {
+	background: var(--hyve-surface);
+	border: 1px solid var(--hyve-border);
+	border-radius: var(--hyve-radius);
+	color: var(--hyve-muted);
+	font-family: ui-monospace, Menlo, Consolas, monospace;
+	font-size: 11px;
+	line-height: 1.6;
+	margin: 0;
+	max-height: 96px;
+	overflow: auto;
+	padding: 8px 10px;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
 /* Static free-tier preview of a Pro surface: visible but inert. */
 .hyve-next-demo {
 	opacity: 0.6;

--- a/tests/e2e/specs/messages.spec.js
+++ b/tests/e2e/specs/messages.spec.js
@@ -133,6 +133,191 @@ test.describe( 'Messages', () => {
 		).toBeVisible();
 	} );
 
+	test( 'a bot reply with a trace shows the debug ledger', async ( {
+		page,
+		admin,
+	} ) => {
+		await page.route(
+			/.*(?:rest_route=%2Fhyve%2Fv1%2Fthreads|\/wp-json\/hyve\/v1\/threads).*/,
+			async ( route ) => {
+				await route.fulfill( {
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify( {
+						posts: [
+							{
+								ID: 7,
+								title: 'Can I book overnight care?',
+								date: '2026-08-17T10:00:00+00:00',
+								thread_id: 'conv_demo123',
+								thread: [
+									{
+										time: 1755424800,
+										sender: 'user',
+										message: 'Can I book overnight care?',
+									},
+									{
+										time: 1755424806,
+										sender: 'bot',
+										message:
+											"Sorry, I'm not able to help with that.",
+										debug: {
+											answered: false,
+											mode: 'self_hosted',
+											transport: 'poll',
+											model: 'gpt-5.4-nano',
+											duration_ms: 6240,
+											usage: {
+												input: 4211,
+												output: 187,
+											},
+											threshold: 0.25,
+											tools_used: true,
+											tool_iterations: 1,
+											skills: [ 'hyve/search-content' ],
+											skill_calls: [
+												{
+													name: 'hyve/search-content',
+													args: '{"query":"overnight"}',
+													output: '{"count":1}',
+													error: false,
+												},
+											],
+											page: 'https://example.com/booking/',
+											page_context: true,
+											follow_ups: [
+												'How far ahead should I book?',
+											],
+											context: [
+												{
+													post_id: 5,
+													title: 'Services &#038; Rates',
+													score: 0.7143,
+													tokens: 119,
+												},
+												{
+													post_id: 14,
+													title: 'Booking Guide',
+													score: 0.6821,
+													tokens: 573,
+												},
+												{
+													post_id: 15,
+													title: 'Billing',
+													score: 0.3122,
+													tokens: 97,
+													included: false,
+												},
+											],
+											raw_reply:
+												'The booking lookup timed out before I could confirm a slot.',
+											query: 'Can I book overnight care?\nBooking Guide',
+										},
+									},
+									{
+										time: 1755424860,
+										sender: 'event',
+										message: 'moderation_flagged',
+										debug: {
+											code: 'content_flagged',
+											categories: [ 'harassment' ],
+											detail: 'harassment',
+										},
+									},
+									{
+										time: 1755424920,
+										sender: 'event',
+										message: 'rate_limited',
+									},
+								],
+							},
+						],
+						more: false,
+						total: 1,
+						per_page: 3,
+					} ),
+				} );
+			}
+		);
+
+		await admin.visitAdminPage( `${ HYVE_ADMIN }&nav=messages` );
+
+		await page.getByRole( 'button', { name: 'View' } ).first().click();
+
+		// The timestamp line summarizes the turn: status, included-source
+		// count (the dropped one is not counted) and the toggle.
+		await expect(
+			page.getByText( 'Not answered', { exact: true } )
+		).toBeVisible();
+		await expect( page.getByText( '2 sources' ) ).toBeVisible();
+
+		await page.getByRole( 'button', { name: 'Show trace' } ).click();
+
+		// Ledger facts.
+		await expect( page.getByText( 'Self-hosted · poll' ) ).toBeVisible();
+		await expect( page.getByText( 'gpt-5.4-nano' ) ).toBeVisible();
+		await expect( page.getByText( '6.2s' ) ).toBeVisible();
+		await expect( page.getByText( '4,211 in · 187 out' ) ).toBeVisible();
+		await expect( page.getByText( '0.25', { exact: true } ) ).toBeVisible();
+
+		// Skills: name, round trips and the executed call.
+		await expect(
+			page.getByText( 'hyve/search-content · 1 round trip' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'hyve/search-content({"query":"overnight"})' )
+		).toBeVisible();
+
+		// Page row links to the visitor's page and notes the injected context.
+		await expect(
+			page.getByRole( 'link', { name: '/booking/' } )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'content included as context' )
+		).toBeVisible();
+
+		// Follow-ups offered to the visitor.
+		await expect(
+			page.getByText( 'How far ahead should I book?' )
+		).toBeVisible();
+
+		// Sources: entity-decoded title, and the budget-drop footnote.
+		await expect( page.getByText( 'Services & Rates' ) ).toBeVisible();
+		await expect(
+			page.getByText( 'the context budget was full', { exact: false } )
+		).toBeVisible();
+
+		// The raw model reply and the retrieval query.
+		await expect(
+			page.getByText(
+				'The booking lookup timed out before I could confirm a slot.'
+			)
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Can I book overnight care?\nBooking Guide' )
+		).toBeVisible();
+
+		// The toggle collapses the ledger again.
+		await page.getByRole( 'button', { name: 'Hide trace' } ).click();
+		await expect( page.getByText( 'gpt-5.4-nano' ) ).toBeHidden();
+		await expect(
+			page.getByRole( 'button', { name: 'Show trace' } )
+		).toBeVisible();
+
+		// Failed turns render as event dividers, not bot bubbles: the
+		// moderation event carries its flagged category as a detail.
+		await expect(
+			page.getByText(
+				'Message was flagged by moderation — no reply was sent · harassment'
+			)
+		).toBeVisible();
+		await expect(
+			page.getByText(
+				'Visitor hit the rate limit — the message was not answered'
+			)
+		).toBeVisible();
+	} );
+
 	test( 'an unknown deep-linked conversation shows the not-found state', async ( {
 		page,
 		admin,

--- a/tests/php/unit/tests/test-chat-events.php
+++ b/tests/php/unit/tests/test-chat-events.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Test_Chat_Events class.
+ *
+ * @package Codeinwp/HyveLite
+ */
+
+use ThemeIsle\HyveLite\API;
+use ThemeIsle\HyveLite\Threads;
+
+/**
+ * Class Test_Chat_Events.
+ *
+ * Covers the event entries recorded for failed chat turns (moderation flags,
+ * rate limits, hard errors): the visitor's message is kept, the failure lands
+ * as an `event` divider — never as a bot reply — and abusive rate-limited
+ * traffic cannot grow the database.
+ */
+class Test_Chat_Events extends WP_UnitTestCase {
+
+	/**
+	 * Read the transcript of a thread.
+	 *
+	 * @param int $post_id The thread post ID.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function entries( $post_id ) {
+		$thread_data = get_post_meta( $post_id, '_hyve_thread_data', true );
+
+		$this->assertIsArray( $thread_data );
+
+		return $thread_data;
+	}
+
+	/**
+	 * A moderation-flagged first turn records the visitor message plus a
+	 * moderation event with the flagged categories — and no bot reply.
+	 */
+	public function test_moderation_failure_records_message_and_event() {
+		API::instance()->record_chat_failure(
+			'',
+			null,
+			'An innocent question',
+			false,
+			'content_flagged',
+			'This message was flagged.',
+			[ 'harassment' => 0.91 ]
+		);
+
+		$threads = get_posts(
+			[
+				'post_type'      => 'hyve_threads',
+				'posts_per_page' => 1,
+				'post_status'    => 'publish',
+			]
+		);
+
+		$this->assertCount( 1, $threads );
+
+		$entries = $this->entries( $threads[0]->ID );
+
+		$this->assertCount( 2, $entries );
+		$this->assertSame( 'user', $entries[0]['sender'] );
+		$this->assertSame( 'An innocent question', $entries[0]['message'] );
+		$this->assertSame( 'event', $entries[1]['sender'] );
+		$this->assertSame( 'moderation_flagged', $entries[1]['message'] );
+		$this->assertSame( [ 'harassment' ], $entries[1]['debug']['categories'] );
+		$this->assertSame( 'harassment', $entries[1]['debug']['detail'] );
+	}
+
+	/**
+	 * A later successful turn adopts the real conversation id instead of
+	 * forking a second thread off the failed turn's placeholder.
+	 */
+	public function test_failed_first_turn_thread_adopts_real_conversation_id() {
+		API::instance()->record_chat_failure( '', null, 'Hello?', false, 'no_embeddings', 'Embedding failed.' );
+
+		$threads = get_posts(
+			[
+				'post_type'      => 'hyve_threads',
+				'posts_per_page' => 5,
+				'post_status'    => 'publish',
+			]
+		);
+
+		$this->assertCount( 1, $threads );
+		$record_id = $threads[0]->ID;
+
+		$result = Threads::add_message(
+			$record_id,
+			[
+				'thread_id' => 'conv_real_123',
+				'sender'    => 'user',
+				'message'   => 'Hello again',
+			]
+		);
+
+		// Same thread, no fork; the placeholder id was replaced.
+		$this->assertSame( $record_id, $result );
+		$this->assertSame( 'conv_real_123', get_post_meta( $record_id, '_hyve_thread_id', true ) );
+		$this->assertCount( 3, $this->entries( $record_id ) );
+	}
+
+	/**
+	 * Rate-limit events only land on existing threads and consecutive
+	 * occurrences collapse into a single event.
+	 */
+	public function test_rate_limited_event_is_bounded() {
+		// No thread: nothing recorded, nothing created.
+		$this->assertFalse( API::instance()->record_rate_limited_event( 12345 ) );
+
+		$record_id = Threads::create_thread(
+			'Hi',
+			[
+				'thread_id' => 'conv_1',
+				'sender'    => 'user',
+				'message'   => 'Hi',
+			]
+		);
+
+		$this->assertTrue( API::instance()->record_rate_limited_event( $record_id ) );
+		$this->assertFalse( API::instance()->record_rate_limited_event( $record_id ) );
+		$this->assertFalse( API::instance()->record_rate_limited_event( $record_id ) );
+
+		$entries = $this->entries( $record_id );
+
+		$this->assertCount( 2, $entries );
+		$this->assertSame( 'event', $entries[1]['sender'] );
+		$this->assertSame( 'rate_limited', $entries[1]['message'] );
+	}
+
+	/**
+	 * An error on an already-recorded turn appends only the event marker,
+	 * and admin test chats record nothing.
+	 */
+	public function test_error_event_appends_marker_only() {
+		$record_id = Threads::create_thread(
+			'Hi',
+			[
+				'thread_id' => 'conv_2',
+				'sender'    => 'user',
+				'message'   => 'Hi',
+			]
+		);
+
+		API::instance()->record_error_event( 'conv_2', $record_id, 'openai_error', 'HTTP 500 from the API.' );
+
+		$entries = $this->entries( $record_id );
+
+		$this->assertCount( 2, $entries );
+		$this->assertSame( 'event', $entries[1]['sender'] );
+		$this->assertSame( 'chat_error', $entries[1]['message'] );
+		$this->assertSame( 'openai_error', $entries[1]['debug']['code'] );
+		$this->assertSame( 'HTTP 500 from the API.', $entries[1]['debug']['detail'] );
+
+		// Test chats never record.
+		API::instance()->record_error_event( 'conv_2', $record_id, 'openai_error', 'again', true );
+		$this->assertCount( 2, $this->entries( $record_id ) );
+	}
+}

--- a/tests/php/unit/tests/test-connect-chat.php
+++ b/tests/php/unit/tests/test-connect-chat.php
@@ -80,4 +80,72 @@ class ConnectChatTest extends WP_UnitTestCase {
 		$this->assertSame( 1, (int) Threads::get_thread_count() );
 		$this->assertSame( 2, (int) get_post_meta( (int) $sent['record_id'], '_hyve_thread_count', true ) );
 	}
+
+	/**
+	 * A Connect reply records its debug trace: mode and transport, the latency
+	 * measured around the platform call, the visitor's page, and the sources
+	 * and usage the platform reported. Retrieval details (query, threshold)
+	 * stay platform-side and are absent by design.
+	 */
+	public function test_connect_poll_chat_records_debug_trace() {
+		update_option( 'hyve_settings', [ 'ai_mode' => Hyve_Connect::MODE_CONNECT ] );
+
+		$this->intercept_job_complete(
+			[
+				'thread_id' => 'th-2',
+				'answered'  => true,
+				'reply'     => 'Laundry is $32.00/hr.',
+				'sources'   => [
+					[
+						'id'    => 42,
+						'title' => 'Services & Rates',
+						'score' => 0.6123,
+					],
+				],
+				'usage'     => [
+					'input_tokens'  => 900,
+					'output_tokens' => 40,
+				],
+			]
+		);
+
+		$send = new WP_REST_Request( 'POST', '/hyve/v1/chat' );
+		$send->set_param( 'message', 'How much is laundry?' );
+		$send->set_param( 'page_url', home_url( '/rates/' ) );
+
+		$sent = API::instance()->send_chat( $send )->get_data();
+
+		$poll = new WP_REST_Request( 'GET', '/hyve/v1/chat' );
+		$poll->set_param( 'run_id', $sent['query_run'] );
+
+		API::instance()->get_chat( $poll );
+
+		$entries = get_post_meta( (int) $sent['record_id'], '_hyve_thread_data', true );
+		$bot     = end( $entries );
+
+		$this->assertSame( 'bot', $bot['sender'] );
+		$this->assertArrayHasKey( 'debug', $bot );
+
+		$debug = $bot['debug'];
+
+		$this->assertTrue( $debug['answered'] );
+		$this->assertSame( 'connect', $debug['mode'] );
+		$this->assertSame( 'poll', $debug['transport'] );
+		$this->assertIsInt( $debug['duration_ms'] );
+		$this->assertSame( home_url( '/rates/' ), $debug['page'] );
+		$this->assertCount( 1, $debug['context'] );
+		$this->assertSame( 42, $debug['context'][0]['post_id'] );
+		$this->assertSame( 0.6123, $debug['context'][0]['score'] );
+		$this->assertSame(
+			[
+				'input'  => 900,
+				'output' => 40,
+			],
+			$debug['usage']
+		);
+
+		// Platform-side retrieval details are not knowable plugin-side.
+		$this->assertArrayNotHasKey( 'query', $debug );
+		$this->assertArrayNotHasKey( 'threshold', $debug );
+	}
 }

--- a/tests/php/unit/tests/test-threads-debug.php
+++ b/tests/php/unit/tests/test-threads-debug.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Test_Threads_Debug class.
+ *
+ * @package Codeinwp/HyveLite
+ */
+
+use ThemeIsle\HyveLite\API;
+use ThemeIsle\HyveLite\Threads;
+
+/**
+ * Class Test_Threads_Debug.
+ *
+ * Covers the per-message debug trace recorded with bot replies (issue: event
+ * information in messages history), so an answer — or a refusal — can be
+ * explained from the Messages screen after the fact.
+ */
+class Test_Threads_Debug extends WP_UnitTestCase {
+
+	/**
+	 * The Threads instance under test.
+	 *
+	 * @var Threads
+	 */
+	private $threads;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->threads = new Threads();
+	}
+
+	/**
+	 * Create a thread with an initial user message and return its post ID.
+	 *
+	 * @return int
+	 */
+	private function create_thread() {
+		return Threads::create_thread(
+			'Hello',
+			[
+				'thread_id' => 'thread-1',
+				'sender'    => 'user',
+				'message'   => 'Hello',
+			]
+		);
+	}
+
+	/**
+	 * Read the last transcript entry of a thread.
+	 *
+	 * @param int $post_id The thread post ID.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function last_entry( $post_id ) {
+		$thread_data = get_post_meta( $post_id, '_hyve_thread_data', true );
+
+		$this->assertIsArray( $thread_data );
+
+		return end( $thread_data );
+	}
+
+	/**
+	 * A bot reply records its debug trace and the answered flag.
+	 */
+	public function test_record_message_persists_debug_trace() {
+		$post_id = $this->create_thread();
+
+		$this->threads->record_message(
+			'run-1',
+			'thread-1',
+			'How much does laundry cost?',
+			$post_id,
+			[
+				'success' => true,
+				'debug'   => [
+					'mode'      => 'self_hosted',
+					'transport' => 'poll',
+					'threshold' => 0.4,
+					'query'     => 'How much does laundry cost?',
+					'context'   => [
+						[
+							'post_id' => 7,
+							'title'   => 'Rates',
+							'score'   => 0.6123,
+							'tokens'  => 512,
+						],
+					],
+				],
+			],
+			'Laundry is $32.00/hr.'
+		);
+
+		$entry = $this->last_entry( $post_id );
+
+		$this->assertSame( 'bot', $entry['sender'] );
+		$this->assertArrayHasKey( 'debug', $entry );
+		$this->assertTrue( $entry['debug']['answered'] );
+		$this->assertSame( 0.4, $entry['debug']['threshold'] );
+		$this->assertSame( 'self_hosted', $entry['debug']['mode'] );
+		$this->assertCount( 1, $entry['debug']['context'] );
+		$this->assertSame( 7, $entry['debug']['context'][0]['post_id'] );
+	}
+
+	/**
+	 * An unanswered reply is recorded as such, even when retrieval found nothing.
+	 */
+	public function test_record_message_marks_unanswered_turn() {
+		$post_id = $this->create_thread();
+
+		$this->threads->record_message(
+			'run-2',
+			'thread-1',
+			'What is your email address?',
+			$post_id,
+			[
+				'success' => false,
+				'debug'   => [
+					'mode'    => 'self_hosted',
+					'context' => [],
+				],
+			],
+			'Sorry, I am not able to help with that.'
+		);
+
+		$entry = $this->last_entry( $post_id );
+
+		$this->assertFalse( $entry['debug']['answered'] );
+		$this->assertSame( [], $entry['debug']['context'] );
+	}
+
+	/**
+	 * A payload with a success flag but no debug data still records the
+	 * answered state, so Connect turns and older flows stay covered.
+	 */
+	public function test_record_message_records_answered_without_debug() {
+		$post_id = $this->create_thread();
+
+		$this->threads->record_message(
+			'run-3',
+			'thread-1',
+			'Hi',
+			$post_id,
+			[ 'success' => true ],
+			'Hi there!'
+		);
+
+		$entry = $this->last_entry( $post_id );
+
+		$this->assertSame( [ 'answered' => true ], $entry['debug'] );
+	}
+
+	/**
+	 * A payload without a success flag or debug data records no debug key,
+	 * matching the previous entry shape.
+	 */
+	public function test_record_message_without_debug_keeps_legacy_shape() {
+		$post_id = $this->create_thread();
+
+		$this->threads->record_message(
+			'run-4',
+			'thread-1',
+			'Hi',
+			$post_id,
+			[],
+			'Hi there!'
+		);
+
+		$entry = $this->last_entry( $post_id );
+
+		$this->assertArrayNotHasKey( 'debug', $entry );
+	}
+
+	/**
+	 * Finalizing the debug trace merges reply-time facts over the retrieval
+	 * trace and lets extensions extend it through the filter.
+	 */
+	public function test_finalize_chat_debug_merges_and_filters() {
+		$callback = function ( $debug ) {
+			$debug['skills'] = [ 'search_products' ];
+
+			return $debug;
+		};
+
+		add_filter( 'hyve_chat_debug', $callback );
+
+		$debug = API::finalize_chat_debug(
+			[
+				'threshold' => 0.4,
+				'context'   => [],
+			],
+			[
+				'mode'       => 'self_hosted',
+				'transport'  => 'stream',
+				'tools_used' => true,
+			],
+			[ 'success' => true ]
+		);
+
+		remove_filter( 'hyve_chat_debug', $callback );
+
+		$this->assertSame( 0.4, $debug['threshold'] );
+		$this->assertSame( 'stream', $debug['transport'] );
+		$this->assertTrue( $debug['tools_used'] );
+		$this->assertSame( [ 'search_products' ], $debug['skills'] );
+	}
+
+	/**
+	 * Finalizing computes the turn latency from the started timestamp, and
+	 * captures follow-ups and the raw model reply on unanswered turns.
+	 */
+	public function test_finalize_chat_debug_enriches_turn_facts() {
+		$debug = API::finalize_chat_debug(
+			[ 'started' => microtime( true ) - 1.5 ],
+			[ 'mode' => 'self_hosted' ],
+			[
+				'success'    => false,
+				'response'   => 'The model said something the visitor never saw.',
+				'follow_ups' => [ 'What are your rates?', '', 42 ],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'started', $debug );
+		$this->assertGreaterThanOrEqual( 1400, $debug['duration_ms'] );
+		$this->assertLessThan( 5000, $debug['duration_ms'] );
+		$this->assertSame( [ 'What are your rates?' ], $debug['follow_ups'] );
+		$this->assertSame( 'The model said something the visitor never saw.', $debug['raw_reply'] );
+	}
+
+	/**
+	 * An answered turn records no raw reply: the visitor already saw the text.
+	 */
+	public function test_finalize_chat_debug_skips_raw_reply_when_answered() {
+		$debug = API::finalize_chat_debug(
+			[],
+			[],
+			[
+				'success'  => true,
+				'response' => 'Personal care costs $35.00 per hour.',
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'raw_reply', $debug );
+	}
+
+	/**
+	 * Usage objects from the Responses API (and array equivalents) normalize
+	 * into the compact stored shape; unreadable input returns null.
+	 */
+	public function test_normalize_usage() {
+		$usage = API::normalize_usage(
+			(object) [
+				'input_tokens'  => 1911,
+				'output_tokens' => 62,
+			]
+		);
+
+		$this->assertSame(
+			[
+				'input'  => 1911,
+				'output' => 62,
+			],
+			$usage 
+		);
+
+		$this->assertSame(
+			[
+				'input'  => 10,
+				'output' => 5,
+			],
+			API::normalize_usage(
+				[
+					'input'  => 10,
+					'output' => 5,
+				] 
+			)
+		);
+
+		$this->assertNull( API::normalize_usage( 'not-usage' ) );
+		$this->assertNull( API::normalize_usage( [ 'foo' => 'bar' ] ) );
+	}
+
+	/**
+	 * The Connect trace maps the platform-reported sources into the stored
+	 * trace shape and ignores malformed rows.
+	 */
+	public function test_connect_debug_maps_platform_sources() {
+		$debug = API::instance()->connect_debug(
+			[
+				'sources' => [
+					[
+						'id'    => 12,
+						'title' => 'Pricing',
+						'score' => 0.51234,
+					],
+					'not-an-array',
+				],
+			]
+		);
+
+		$this->assertCount( 1, $debug['context'] );
+		$this->assertSame( 12, $debug['context'][0]['post_id'] );
+		$this->assertSame( 'Pricing', $debug['context'][0]['title'] );
+		$this->assertSame( 0.5123, $debug['context'][0]['score'] );
+
+		$this->assertSame( [], API::instance()->connect_debug( [] ) );
+	}
+}


### PR DESCRIPTION
## Summary

Closes Codeinwp/hyve#300
Pro PR: https://github.com/Codeinwp/hyve/pull/301

Until now, the Messages screen only showed what the visitor and the bot said, with no way to tell why a reply came out the way it did. This PR records a debug trace with every bot reply and surfaces it in the conversation view.

Each bot reply now shows a summary line (answered or not, number of sources used) with a **Show trace** toggle that expands a detail panel:

- **Answered by**: self-hosted or Hyve Connect, poll or stream
- **Model, latency and token usage** for the turn
- **Sources**: which knowledge base entries matched, with similarity score bars, the threshold marker, and entries that matched but were dropped because the context was full
- **Page**: the page the visitor chatted from, and whether its content was used as context
- **Skills** used during the turn and what they returned (Pro)
- **Follow-ups** suggested to the visitor
- **Model reply & retrieval query**: the raw reply (when a reply wasn't shown to the visitor) and the query used to search the knowledge base

Failed turns are no longer lost: messages flagged by moderation, rate-limited visitors and API errors now appear as event markers in the conversation. The visitor's message is kept, and the failure is never recorded as a bot reply. Repeated rate-limit hits collapse into a single event so abuse can't grow the database.

Also fixed along the way:

- A temporary moderation API outage was reported to the visitor as "your message was flagged". It now returns a proper "try again" error.
- A failed first message used to fork the conversation into two threads.

Works across all four reply paths: self-hosted and Hyve Connect, polling and streaming. Older conversations without traces render exactly as before.

## Screenshots

<img width="1130" height="1001" alt="Screenshot 2026-08-17 at 3 18 47 PM" src="https://github.com/user-attachments/assets/2434edd7-c131-45fe-a879-23dba3a7140a" />
<img width="651" height="850" alt="Screenshot 2026-08-17 at 1 26 31 PM" src="https://github.com/user-attachments/assets/f6adad7b-d1f6-4b0b-a369-6448f57c1ef5" />


## QA instructions

1. With **self-hosted mode** and a populated knowledge base, ask the chatbot a few questions on the frontend (some it can answer, some it can't).
2. Go to **Hyve → Messages** and open the conversation. Each bot reply should show a line like *"Answered · 3 sources · Show trace"*.
3. Click **Show trace** and check the panel shows the model, latency, tokens, threshold and the source list with score bars. Hover the small **?** icons to see the help text. Click **Hide trace** to collapse it.
4. Ask a question the bot can't answer. The trace should say **Not answered** and include the raw model reply.
5. Ask a question from a regular page (not the homepage). The trace's **Page** row should link to that page.
6. Send an abusive/offensive message. The conversation should show a *"flagged by moderation"* event divider instead of a bot reply, and the visitor's message should still be recorded.
7. Send messages rapidly until rate-limited. A single *"rate limit"* event should appear, without duplicates for repeated attempts.
8. Switch to **Hyve Connect** mode and repeat a couple of questions. Traces should show *"Hyve Connect"* with latency, tokens and sources (no threshold or score bars, that data stays on the platform).
9. Open an old conversation created before this update. It should look unchanged.